### PR TITLE
Use confluent_pom.xml for docker build.

### DIFF
--- a/cc-docker-connect-snowflake/Makefile
+++ b/cc-docker-connect-snowflake/Makefile
@@ -17,7 +17,7 @@ cc-connect-snowflake-sink:
 	[ -d kafka-connect-snowflake ] || git clone git@github.com:snowflakedb/snowflake-kafka-connector.git kafka-connect-snowflake
 	git -C kafka-connect-snowflake checkout master
 	git -C kafka-connect-snowflake pull origin master
-	mvn -f kafka-connect-snowflake -am -Dconnect.component.version=ccloud -Dmaven.test.skip=true clean package
+	mvn -f kafka-connect-snowflake/pom_confluent.xml -am -Dconnect.component.version=ccloud -Dmaven.test.skip=true clean package
 	docker build \
 		-t confluentinc/cc-connect-snowflake-sink:$(IMAGE_VERSION) \
 		--build-arg BASE_VERSION=$(BASE_VERSION) \


### PR DESCRIPTION
Use confluent_pom.xml for docker build.
Background: Snowflake used a separate pom file for Confluent release 
https://github.com/snowflakedb/snowflake-kafka-connector/pull/163
With the current build command, we cannot get the package, so the last COPY step would fail.