### PR TITLE
Fix potential NPE in int64 conversion.

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -246,9 +246,9 @@ public class RecordService extends Logging
           }
           return JsonNodeFactory.instance.numberNode((Integer) value);
         case INT64:
-          String schemaName = schema.name();
-          if(Timestamp.LOGICAL_NAME.equals(schemaName)){
-            return JsonNodeFactory.instance.numberNode(Timestamp.fromLogical(schema, (java.util.Date) value));
+          if (schema != null && Timestamp.LOGICAL_NAME.equals(schema.name())) {
+            return JsonNodeFactory.instance.numberNode(
+                Timestamp.fromLogical(schema, (java.util.Date) value));
           }
           return JsonNodeFactory.instance.numberNode((Long) value);
         case FLOAT32:
@@ -261,7 +261,7 @@ public class RecordService extends Logging
           CharSequence charSeq = (CharSequence) value;
           return JsonNodeFactory.instance.textNode(charSeq.toString());
         case BYTES:
-          if (Decimal.LOGICAL_NAME.equals(schema.name())) {
+          if (schema != null && Decimal.LOGICAL_NAME.equals(schema.name())) {
             return JsonNodeFactory.instance.numberNode((BigDecimal) value);
           }
 

--- a/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
@@ -150,10 +150,14 @@ public class ConverterTest
     Map<String, ?> config = Collections.singletonMap("schemas.enable", false);
     jsonConverter.configure(config, false);
     Map<String, Object> jsonMap = new HashMap<>();
-    // Value will map to int64
-    jsonMap.put("test3", Integer.MAX_VALUE);
+    // Value will map to int64.
+    jsonMap.put("test", Integer.MAX_VALUE);
     SchemaAndValue schemaAndValue =
         jsonConverter.toConnectData("test", mapper.writeValueAsBytes(jsonMap));
-    RecordService.convertToJson(schemaAndValue.schema(), schemaAndValue.value());
+    JsonNode result = RecordService.convertToJson(schemaAndValue.schema(), schemaAndValue.value());
+
+    ObjectNode expected = mapper.createObjectNode();
+    expected.put("test", Integer.MAX_VALUE);
+    assert expected.toString().equals(result.toString());
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
@@ -17,12 +17,17 @@
 package com.snowflake.kafka.connector.records;
 
 import com.snowflake.kafka.connector.mock.MockSchemaRegistryClient;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.core.JsonProcessingException;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind
   .ObjectMapper;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node
   .ObjectNode;
 import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.json.JsonConverter;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -137,5 +142,18 @@ public class ConverterTest
     assert ((SnowflakeRecordContent) result.value()).isBroken();
     assert Arrays.equals(data,
       ((SnowflakeRecordContent) result.value()).getBrokenData());
+  }
+
+  @Test
+  public void testConnectJsonConverter_MapInt64() throws JsonProcessingException {
+    JsonConverter jsonConverter = new JsonConverter();
+    Map<String, ?> config = Collections.singletonMap("schemas.enable", false);
+    jsonConverter.configure(config, false);
+    Map<String, Object> jsonMap = new HashMap<>();
+    // Value will map to int64
+    jsonMap.put("test3", Integer.MAX_VALUE);
+    SchemaAndValue schemaAndValue =
+        jsonConverter.toConnectData("test", mapper.writeValueAsBytes(jsonMap));
+    RecordService.convertToJson(schemaAndValue.schema(), schemaAndValue.value());
   }
 }


### PR DESCRIPTION
## Problem
With `org.apache.kafka.connect.json.JsonConverter`, integers are of type int64. When converting to JSON in `RecordService`, there is a potential NPE if value has no schema.

## Solution
Check if schema is null before accessing its name.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [x] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
