### PR TITLE
Handle null key in case map schema is an empty map.

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -299,7 +299,7 @@ public class RecordService extends Logging
               }
             }
           } else {
-            objectMode = schema.keySchema().type() == Schema.Type.STRING;
+            objectMode = schema.keySchema() == null || schema.keySchema().type() == Schema.Type.STRING;
           }
           ObjectNode obj = null;
           ArrayNode list = null;

--- a/src/test/java/com/snowflake/kafka/connector/records/HeaderTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/HeaderTest.java
@@ -4,6 +4,7 @@ import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.header.ConnectHeaders;
@@ -192,6 +193,22 @@ public class HeaderTest
     assert headerNode.get(structName).get(key2).asLong() == value2;
 
 
+  }
+
+  @Test
+  public void testEmptyMap()throws IOException {
+    Schema MAP_SCHEMA = new SchemaBuilder(Type.MAP);
+    String mapName = "properties";
+    Headers headers = new ConnectHeaders()
+        .addMap(mapName, Collections.emptyMap(), MAP_SCHEMA);
+    SinkRecord record = createTestRecord(headers);
+    RecordService service = new RecordService();
+    JsonNode node = MAPPER.readTree(service.processRecord(record));
+
+    assert node.get("meta").has("headers");
+    JsonNode headerNode = node.get("meta").get("headers");
+    assert headerNode.has(mapName);
+    assert headerNode.get(mapName).asText().equals("");
   }
 
   private static SinkRecord createTestRecord(Headers headers) throws IOException


### PR DESCRIPTION
## Problem
The records received by Azure Event Hubs source connector contains empty map values in the headers, e.g. 
```
{
  "key": "properties",
  "stringValue": "{}"
}
```
This causes Snowflake sink connector to throw an NPE when parsing headers.

## Solution
Check for null key schema.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
