### PR TITLE
Do not lose precision in RecordService#convertToJson for numbers, that exceed Snowflake's limit of 38 significant digits.

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -28,7 +28,6 @@ import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.*;
 import org.apache.kafka.connect.data.Date;
-import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.sink.SinkRecord;

--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -55,6 +55,8 @@ public class RecordService extends Logging
 
   public static final SimpleDateFormat ISO_DATE_FORMAT= new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
   public static final SimpleDateFormat TIME_FORMAT= new SimpleDateFormat("HH:mm:ss.SSSZ");
+  private static final int MAX_SNOWFLAKE_NUMBER_PRECISION = 38;
+
   static{
     ISO_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
   }
@@ -273,7 +275,12 @@ public class RecordService extends Logging
           return JsonNodeFactory.instance.textNode(charSeq.toString());
         case BYTES:
           if (schema != null && Decimal.LOGICAL_NAME.equals(schema.name())) {
-            return JsonNodeFactory.instance.numberNode((BigDecimal) value);
+            BigDecimal bigDecimalValue = (BigDecimal) value;
+            if (bigDecimalValue.precision() > MAX_SNOWFLAKE_NUMBER_PRECISION) {
+              // in order to prevent losing precision, convert this value to text
+              return JsonNodeFactory.instance.textNode(bigDecimalValue.toString());
+            }
+            return JsonNodeFactory.instance.numberNode(bigDecimalValue);
           }
 
           byte[] valueArr = null;

--- a/src/test/java/com/snowflake/kafka/connector/records/HeaderTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/HeaderTest.java
@@ -60,6 +60,9 @@ public class HeaderTest
     String bigDecimalName = "bigDecimal";
     BigDecimal bigDecimalData = new BigDecimal("1234.1234");
 
+    String bigDecimalExceedsMaxPrecisionName = "bigDecimalExceedsMaxPrecision";
+    BigDecimal bigDecimalExceedsMaxPrecisionData = new BigDecimal("999999999999999999999999999999999999999");
+
     String dateName = "date";
     Date dateData = new Date(1577836800000L);
     String timeName = "time";
@@ -77,6 +80,7 @@ public class HeaderTest
     headers.addString(stringName, stringData);
     headers.addBytes(bytesName, bytesData);
     headers.addDecimal(bigDecimalName, bigDecimalData);
+    headers.addDecimal(bigDecimalExceedsMaxPrecisionName, bigDecimalExceedsMaxPrecisionData);
     headers.addDate(dateName, dateData);
     headers.addTime(timeName, timeData);
     headers.addTimestamp(timestampName, timestampData);
@@ -113,6 +117,7 @@ public class HeaderTest
     assert headerNode.get(timeName).asText().equals(TIME_FORMAT.format(timeData));
     assert headerNode.has(timestampName);
     assert headerNode.get(timestampName).asLong() == timestampData.getTime();
+    assert headerNode.get(bigDecimalExceedsMaxPrecisionName).asText().equals(bigDecimalExceedsMaxPrecisionData.toString());
 
     //array
     headers = new ConnectHeaders();

--- a/src/test/java/com/snowflake/kafka/connector/records/HeaderTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/HeaderTest.java
@@ -44,14 +44,15 @@ public class HeaderTest
     String shortName = "short";
     short shortData = 128;
     String intName = "int";
-    int intData = 32767;
+    int intData = Integer.MAX_VALUE;
     String longName = "long";
-    long longData = 1234567890123L;
+    long longData = Long.MAX_VALUE;
     String floatName = "float";
-    float floatData = 1.234f;
+    float floatData = 1/3f;
     String doubleName = "double";
-    double doubleData = 123.23432532345;
+    double doubleData = 1/3d;
     String booleanName = "boolean";
+
     boolean booleanData = true;
     String stringName = "string";
     String stringData = "test test";


### PR DESCRIPTION
## Problem

Whenever Snowflake connector sinks a record with a header, that has a numeric value, with more than 38 significant numbers, it loses its precision because of `NUMBER` Snowflake datatype. Here is a limitation, described in doc - https://docs.snowflake.com/en/sql-reference/data-types-numeric.html#data-types-for-fixed-point-numbers.

Since the user doesn't want to lose precision, we want to be able to preserve it, even at a cost of sending these values as strings.


## Solution
Update method `convertToJson` to check, whether the decimal value exceeds Snowflake's limit of 38 significant digits and convert it to text node if it does.

Note: there is an AK bug, that was revealed after writing a new unit test for this PR - https://github.com/confluentinc/ce-kafka/pull/2486. The unit test's asserting is commented out until we merge AK PR and release AK, which has the fix. Our fork can have this unit tests earlier if we use `ce-kafka` dependency. 



<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
Upstream repo.


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
