### PR TITLE
Skip gpg when building image.

### DIFF
--- a/cc-docker-connect-snowflake/Makefile
+++ b/cc-docker-connect-snowflake/Makefile
@@ -17,7 +17,7 @@ cc-connect-snowflake-sink:
 	[ -d kafka-connect-snowflake ] || git clone git@github.com:confluentinc/snowflake-kafka-connector.git kafka-connect-snowflake
 	git -C kafka-connect-snowflake checkout master
 	git -C kafka-connect-snowflake pull origin master
-	mvn -f kafka-connect-snowflake/pom_confluent.xml -am -Dconnect.component.version=ccloud -Dmaven.test.skip=true clean package
+	mvn -f kafka-connect-snowflake/pom_confluent.xml -am -Dconnect.component.version=ccloud -Dmaven.test.skip=true -Dgpg.skip clean package
 	docker build \
 		-t confluentinc/cc-connect-snowflake-sink:$(IMAGE_VERSION) \
 		--build-arg BASE_VERSION=$(BASE_VERSION) \


### PR DESCRIPTION
## Problem
Hit error `[ERROR] Failed to execute goal org.apache.maven.plugins:maven-gpg-plugin:1.6:sign (sign-artifacts) on project snowflake-kafka-connector: Unable to execute gpg command: Error while executing process. Cannot run program "gpg": error=2, No such file or directory -> [Help 1]`

## Solution
Skip gpg


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
