### PR TITLE
Add an empty string check for  topic2tables map

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -300,7 +300,9 @@ public class SnowflakeSinkTask extends SinkTask {
    * @return result map
    */
   static Map<String, String> getTopicToTableMap(Map<String, String> config) {
-    if (config.containsKey(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP)) {
+    if (config.containsKey(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP)
+            && !config.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP).isEmpty()
+    ) {
       Map<String, String> result =
           Utils.parseTopicToTableMap(config.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP));
       if (result != null) {

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -415,7 +415,7 @@ public class Utils {
     }
 
     if (config.containsKey(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP)
-            && config.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP).isEmpty()
+            && !config.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP).isEmpty()
             && parseTopicToTableMap(config.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP))
             == null) {
       configIsValid = false;

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -415,7 +415,7 @@ public class Utils {
     }
 
     if (config.containsKey(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP)
-            && !config.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP).equals("")
+            && config.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP).isEmpty()
             && parseTopicToTableMap(config.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP))
             == null) {
       configIsValid = false;

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -415,7 +415,8 @@ public class Utils {
     }
 
     if (config.containsKey(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP)
-        && parseTopicToTableMap(config.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP))
+            && !config.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP).equals("")
+            && parseTopicToTableMap(config.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP))
             == null) {
       configIsValid = false;
     }

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -251,4 +251,11 @@ public class ConnectorConfigTest {
     config.put(SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG, "INVALID");
     Utils.validateConfig(config);
   }
+
+  @Test
+  public void testEmptyTopic2TableMap() {
+    Map<String, String> config = getConfig();
+    config.put(SnowflakeSinkConnectorConfig.TOPICS, "");
+    Utils.validateConfig(config);
+  }
 }


### PR DESCRIPTION
Signed-off-by: SajanaW <sweerawardhena@confluent.io>

## Problem
- We had a cloud issue recently, where the connector failed to start because topic2table map was an empty string. This was an elusive error. For context, the tasks fail when a hot fix was rolled, and then the second hot fix, which was supposed to fix the bug introduced by the first one, was not able to remediate this connector. The reason was topic2table map was causing the connector not to start up/ it errored out.  But this error just gets logged in the connector and a generic error message was being thrown. After much debugging we realized what is going on.  Error took the form:
It logged this
```
[ERROR] 2021-06-22 22:55:32,614 [connector-thread-lcc-36n2w] com.snowflake.kafka.connector.Utils parseTopicToTableMap -
[SF_KAFKA_CONNECTOR] Invalid snowflake.topic2table.map config format:
```


But threw this:

```
[SF_KAFKA_CONNECTOR] Exception: Invalid input connector configuration
[SF_KAFKA_CONNECTOR] Error Code: 0001
[SF_KAFKA_CONNECTOR] Detail: input kafka connector configuration is null, missing required values, or wrong input value
	at com.snowflake.kafka.connector.internal.SnowflakeErrors.getException(SnowflakeErrors.java:281)
	at com.snowflake.kafka.connector.internal.SnowflakeErrors.getException(SnowflakeErrors.java:248)
	at com.snowflake.kafka.connector.Utils.validateConfig(Utils.java:494)
	at com.snowflake.kafka.connector.SnowflakeSinkConnector.start(SnowflakeSinkConnector.java:86)
	at org.apache.kafka.connect.runtime.WorkerConnector.doStart(WorkerConnector.java:185)
	at org.apache.kafka.connect.runtime.WorkerConnector.start(WorkerConnector.java:210)
	at org.apache.kafka.connect.runtime.WorkerConnector.doTransitionTo(WorkerConnector.java:349)
	at org.apache.kafka.connect.runtime.WorkerConnector.doTransitionTo(WorkerConnector.java:332)
	at org.apache.kafka.connect.runtime.WorkerConnector.doRun(WorkerConnector.java:141)
	at org.apache.kafka.connect.runtime.WorkerConnector.run(WorkerConnector.java:118)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
```
- In the connector start method, there is a validation check for topic2table, which fails the connector if is is "". For some reason our lower level configs materialize this config as an empty string. 

## Solution
- For the moment, we are trying to patch by explicity checking if empty string and skipping the validation.

In the future we have to move the validation checks from the SnowFlake start method to the validate method

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Hotfix stag and test