### PR TITLE
Make sink task case insensitive to BehaviorOnNullValues.

### DIFF
--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -456,7 +456,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -20,6 +20,7 @@ import com.snowflake.kafka.connector.internal.*;
 import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
@@ -129,7 +130,8 @@ public class SnowflakeSinkTask extends SinkTask {
       // connector would never start or reach the sink task stage
       behavior =
           SnowflakeSinkConnectorConfig.BehaviorOnNullValues.valueOf(
-              parsedConfig.get(SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG));
+              parsedConfig.get(SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG)
+                  .toUpperCase(Locale.ROOT));
     }
 
     conn =

--- a/src/test/java/com/snowflake/kafka/connector/SinkTaskIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SinkTaskIT.java
@@ -173,4 +173,13 @@ public class SinkTaskIT {
 
     sinkTask.logWarningForPutAndPrecommit(System.currentTimeMillis() - 400 * 1000, 1, "put");
   }
+
+  @Test
+  public void testBehaviorOnNull() {
+    Map<String, String> config = TestUtils.getConf();
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    SnowflakeSinkTask sinkTask = new SnowflakeSinkTask();
+    config.put(SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG, "ignore");
+    sinkTask.start(config);
+  }
 }


### PR DESCRIPTION
## Problem
The validator for BehaviorOnNullValues enum is case insensitive. However, when SinkTask starts, it needs a BehaviorOnNullValues enum in upper case. As a result, a lowercase string value could pass validation but breaks on task startup.

## Solution
Make sink task case insensitive to BehaviorOnNullValues so that both upper case and lower case string value could work.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
