### PR TITLE
CCDB-3870: Don't throw SnowflakeKafkaConnectorException from TopicToTableValidator

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
@@ -356,7 +358,12 @@ public class SnowflakeSinkConnectorConfig {
       String s = (String) value;
       if (s != null && !s.isEmpty()) // this value is optional and can be empty
       {
-        if (Utils.parseTopicToTableMap(s) == null) {
+        try {
+          if (Utils.parseTopicToTableMap(s) == null) {
+            throw new ConfigException(
+                name, value, "Format: <topic-1>:<table-1>,<topic-2>:<table-2>,...");
+          }
+        } catch (SnowflakeKafkaConnectorException e) {
           throw new ConfigException(
               name, value, "Format: <topic-1>:<table-1>,<topic-2>:<table-2>,...");
         }

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -1,9 +1,14 @@
 package com.snowflake.kafka.connector;
 
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TopicToTableValidator;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigException;
 import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
 
 public class ConnectorConfigTest {
   static Map<String, String> getConfig() {
@@ -147,6 +152,26 @@ public class ConnectorConfigTest {
     Map<String, String> config = getConfig();
     config.put(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP, "topic1:table1,topic2:table1");
     Utils.validateConfig(config);
+  }
+
+  @Test
+  public void testTopicToTableValidatorOnlyThrowsConfigException() {
+    assertThrows(ConfigException.class, () -> {
+      new TopicToTableValidator().ensureValid(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP,
+          "$@#$#@%^$12312");
+    });
+    assertThrows(ConfigException.class, () -> {
+      new TopicToTableValidator().ensureValid(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP,
+          "topic1:!@#@!#!@");
+    });
+    assertThrows(ConfigException.class, () -> {
+      new TopicToTableValidator().ensureValid(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP,
+          "topic1:table1,topic1:table2");
+    });
+    assertThrows(ConfigException.class, () -> {
+      new TopicToTableValidator().ensureValid(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP,
+          "topic1:table1,topic2:table1");
+    });
   }
 
   @Test


### PR DESCRIPTION
## Problem
When `parseTopicToTableMap` encounters and invalid topic map, it may return null or it may throw `SnowflakeKafkaConnectorException`. The validator only checks the null return value but does not handle the exception correctly. This causes a 500 error in validation.

## Solution
Catch and rethrow a `ConfigException`

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
Can take the fix back upstream.

## Test Strategy
New unittest added

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Take to cc-docker-connect master and hotfix branches.