### PR TITLE
Pass a validation timeout to Snowflake Connection

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -59,6 +59,8 @@ public class SnowflakeSinkConnector extends SinkConnector {
   // Using setupComplete to synchronize
   private boolean setupComplete;
 
+  private int VALIDATION_NETWORK_TIMEOUT = 45000;
+
   /** No-Arg constructor. Required by Kafka Connect framework */
   public SnowflakeSinkConnector() {
     setupComplete = false;
@@ -231,7 +233,11 @@ public class SnowflakeSinkConnector extends SinkConnector {
     SnowflakeConnectionService testConnection;
     try {
       testConnection =
-          SnowflakeConnectionServiceFactory.builder().setProperties(connectorConfigs).build();
+          SnowflakeConnectionServiceFactory.builder()
+                  .setProperties(connectorConfigs)
+                  .setNetworkTimeout(VALIDATION_NETWORK_TIMEOUT)
+                  .build();
+
     } catch (SnowflakeKafkaConnectorException e) {
       LOGGER.error(
           "Validate: Error connecting to snowflake:{}, errorCode:{}", e.getMessage(), e.getCode());

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -29,6 +29,7 @@ class InternalUtils {
   static final String JDBC_SSL = "ssl";
   static final String JDBC_SESSION_KEEP_ALIVE = "client_session_keep_alive";
   static final String JDBC_WAREHOUSE = "warehouse"; // for test only
+  static final String JDBC_NETWORK_TIMEOUT = "networkTimeout";
 
   // internal parameters
   static final long MAX_RECOVERY_TIME = 10 * 24 * 3600 * 1000; // 10 days
@@ -113,7 +114,7 @@ class InternalUtils {
    * @param sslEnabled if ssl is enabled
    * @return a Properties instance
    */
-  static Properties createProperties(Map<String, String> conf, boolean sslEnabled) {
+  static Properties createProperties(Map<String, String> conf, boolean sslEnabled, int networkTimeout) {
     Properties properties = new Properties();
 
     // decrypt rsa key
@@ -159,6 +160,10 @@ class InternalUtils {
       properties.put(JDBC_SSL, "on");
     } else {
       properties.put(JDBC_SSL, "off");
+    }
+
+    if (networkTimeout != 0) {
+      properties.put(JDBC_NETWORK_TIMEOUT, networkTimeout);
     }
     // put values for optional parameters
     properties.put(JDBC_SESSION_KEEP_ALIVE, "true");

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
@@ -18,6 +18,9 @@ public class SnowflakeConnectionServiceFactory {
     private SnowflakeURL url;
     private String connectorName;
     private String taskID = "-1";
+    // 0 specifies no network timeout is set
+    // https://docs.snowflake.com/en/user-guide/jdbc-parameters.html#networktimeout
+    private int networkTimeOut = 0;
 
     // whether kafka is hosted on premise or on confluent cloud.
     // This info is provided in the connector configuration
@@ -50,12 +53,17 @@ public class SnowflakeConnectionServiceFactory {
       return this;
     }
 
+    public SnowflakeConnectionServiceBuilder setNetworkTimeout(int timeout) {
+      this.networkTimeOut = timeout;
+      return this;
+    }
+
     public SnowflakeConnectionServiceBuilder setProperties(Map<String, String> conf) {
       if (!conf.containsKey(Utils.SF_URL)) {
         throw SnowflakeErrors.ERROR_0017.getException();
       }
       this.url = new SnowflakeURL(conf.get(Utils.SF_URL));
-      this.prop = InternalUtils.createProperties(conf, this.url.sslEnabled());
+      this.prop = InternalUtils.createProperties(conf, this.url.sslEnabled(), this.networkTimeOut);
       this.kafkaProvider =
           SnowflakeSinkConnectorConfig.KafkaProvider.of(conf.get(PROVIDER_CONFIG)).name();
       // TODO: Ideally only one property is required, but because we dont pass it around in JDBC and

--- a/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
@@ -99,7 +99,7 @@ public class ConnectionServiceIT {
         });
 
     SnowflakeURL url = TestUtils.getUrl();
-    Properties prop = InternalUtils.createProperties(TestUtils.getConf(), url.sslEnabled());
+    Properties prop = InternalUtils.createProperties(TestUtils.getConf(), url.sslEnabled(), 0);
     String appName = TestUtils.TEST_CONNECTOR_NAME;
 
     SnowflakeConnectionServiceFactory.builder()

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
@@ -78,7 +78,7 @@ public class InternalUtilsTest {
   public void testCreateProperties() {
     Map<String, String> config = TestUtils.getConf();
     SnowflakeURL url = TestUtils.getUrl();
-    Properties prop = InternalUtils.createProperties(config, url.sslEnabled());
+    Properties prop = InternalUtils.createProperties(config, url.sslEnabled(), 0);
     assert prop.containsKey(InternalUtils.JDBC_DATABASE);
     assert prop.containsKey(InternalUtils.JDBC_PRIVATE_KEY);
     assert prop.containsKey(InternalUtils.JDBC_SCHEMA);
@@ -99,7 +99,7 @@ public class InternalUtilsTest {
         () -> {
           Map<String, String> t = new HashMap<>(config);
           t.remove(Utils.SF_PRIVATE_KEY);
-          InternalUtils.createProperties(t, url.sslEnabled());
+          InternalUtils.createProperties(t, url.sslEnabled(), 0);
         });
 
     assert TestUtils.assertError(
@@ -107,7 +107,7 @@ public class InternalUtilsTest {
         () -> {
           Map<String, String> t = new HashMap<>(config);
           t.remove(Utils.SF_SCHEMA);
-          InternalUtils.createProperties(t, url.sslEnabled());
+          InternalUtils.createProperties(t, url.sslEnabled(), 0);
         });
 
     assert TestUtils.assertError(
@@ -115,7 +115,7 @@ public class InternalUtilsTest {
         () -> {
           Map<String, String> t = new HashMap<>(config);
           t.remove(Utils.SF_DATABASE);
-          InternalUtils.createProperties(t, url.sslEnabled());
+          InternalUtils.createProperties(t, url.sslEnabled(), 0);
         });
 
     assert TestUtils.assertError(
@@ -123,7 +123,7 @@ public class InternalUtilsTest {
         () -> {
           Map<String, String> t = new HashMap<>(config);
           t.remove(Utils.SF_USER);
-          InternalUtils.createProperties(t, url.sslEnabled());
+          InternalUtils.createProperties(t, url.sslEnabled(), 0);
         });
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -124,7 +124,7 @@ public class TestUtils {
 
     SnowflakeURL url = new SnowflakeURL(getConf().get(Utils.SF_URL));
 
-    Properties properties = InternalUtils.createProperties(getConf(), url.sslEnabled());
+    Properties properties = InternalUtils.createProperties(getConf(), url.sslEnabled(), 0);
 
     conn = new SnowflakeDriver().connect(url.getJdbcUrl(), properties);
 


### PR DESCRIPTION
Signed-off-by: SajanaW <sweerawardhena@confluent.io>

We're running into a number of issues in production where Snowflake connection calls hang, which leads to synchronous validation calls hanging on the UI. These synchronous call are then timed out by the gateway - which lead to an ominous error message on the UI: `UNKNOWN ERROR`. 

Let's try to amend that by passing a timeout to snowflake