### PR TITLE
bump log4j-core to 2.16.0 (#362)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,7 +431,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.2</version>
+            <version>2.16.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -481,7 +481,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.2</version>
+            <version>2.16.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Signed-off-by: SajanaW <sweerawardhena@confluent.io>

Old log4j is vulnerable and we can't pull them from artifactory. We need to upgrade to get green pass + be secure.