### PR TITLE
1.5.x cherry pick

### DIFF
--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -456,7 +456,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
@@ -356,7 +358,12 @@ public class SnowflakeSinkConnectorConfig {
       String s = (String) value;
       if (s != null && !s.isEmpty()) // this value is optional and can be empty
       {
-        if (Utils.parseTopicToTableMap(s) == null) {
+        try {
+          if (Utils.parseTopicToTableMap(s) == null) {
+            throw new ConfigException(
+                name, value, "Format: <topic-1>:<table-1>,<topic-2>:<table-2>,...");
+          }
+        } catch (SnowflakeKafkaConnectorException e) {
           throw new ConfigException(
               name, value, "Format: <topic-1>:<table-1>,<topic-2>:<table-2>,...");
         }

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -20,6 +20,7 @@ import com.snowflake.kafka.connector.internal.*;
 import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
@@ -129,7 +130,8 @@ public class SnowflakeSinkTask extends SinkTask {
       // connector would never start or reach the sink task stage
       behavior =
           SnowflakeSinkConnectorConfig.BehaviorOnNullValues.valueOf(
-              parsedConfig.get(SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG));
+              parsedConfig.get(SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG)
+                  .toUpperCase(Locale.ROOT));
     }
 
     conn =

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -1,9 +1,14 @@
 package com.snowflake.kafka.connector;
 
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TopicToTableValidator;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigException;
 import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
 
 public class ConnectorConfigTest {
   static Map<String, String> getConfig() {
@@ -147,6 +152,26 @@ public class ConnectorConfigTest {
     Map<String, String> config = getConfig();
     config.put(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP, "topic1:table1,topic2:table1");
     Utils.validateConfig(config);
+  }
+
+  @Test
+  public void testTopicToTableValidatorOnlyThrowsConfigException() {
+    assertThrows(ConfigException.class, () -> {
+      new TopicToTableValidator().ensureValid(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP,
+          "$@#$#@%^$12312");
+    });
+    assertThrows(ConfigException.class, () -> {
+      new TopicToTableValidator().ensureValid(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP,
+          "topic1:!@#@!#!@");
+    });
+    assertThrows(ConfigException.class, () -> {
+      new TopicToTableValidator().ensureValid(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP,
+          "topic1:table1,topic1:table2");
+    });
+    assertThrows(ConfigException.class, () -> {
+      new TopicToTableValidator().ensureValid(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP,
+          "topic1:table1,topic2:table1");
+    });
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/SinkTaskIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SinkTaskIT.java
@@ -173,4 +173,13 @@ public class SinkTaskIT {
 
     sinkTask.logWarningForPutAndPrecommit(System.currentTimeMillis() - 400 * 1000, 1, "put");
   }
+
+  @Test
+  public void testBehaviorOnNull() {
+    Map<String, String> config = TestUtils.getConf();
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    SnowflakeSinkTask sinkTask = new SnowflakeSinkTask();
+    config.put(SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG, "ignore");
+    sinkTask.start(config);
+  }
 }


### PR DESCRIPTION
Cherry picking changes since the latest release has some diffs compared to the older release. Looks like some commits were missed in the newer release.
This caused an error in existing snowflake connectors where behaviour.on.null was `ignore` (lowercase).

Newer templates have the value for behaviour.on.error as `IGNORE`(uppercase). 
Older templates seem to have behaviour.on.error as `ignore`(lowercase). So, in case there is an issue validating the connector config for such connectors, template materialisation doesn't happen since validation fails and we get an alert with the exception 
`java.lang.IllegalArgumentException: No enum constant com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BehaviorOnNullValues.ignore`

The diff btw the two releases of `snowflake-kafka-connector` is [here](https://github.com/confluentinc/snowflake-kafka-connector/compare/v1.5.5-rc-7dfa5ab...v1.5.5-rc-9176b6d?diff=split#diff-991cd912b53adea31dd6d1d095737c90301bbc195146ff4c7f56d49a1910e2c7R134)

Looks like these changes have been removed from master and 1.5.x branch. I am not completely sure why they were removed. But since this has caused a regression, adding these changes again.