### PR TITLE
CCDB-4680: Snowflake Cleaner thread should kill the task if it fails to verify files have landed in Snowpipe after retries

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -89,6 +89,11 @@ public class SnowflakeSinkConnectorConfig {
   public static final String SNOWFLAKE_METADATA_ALL = "snowflake.metadata.all";
   public static final String SNOWFLAKE_METADATA_DEFAULT = "true";
 
+  private static final String SNOWFLAKE_CLEANER_RESTARTS_CONFIG = "snowflake.cleaner.retries";
+  private static final String SNOWFLAKE_CLEANER_RESTARTS_DISPLAY = "Snowflake Cleaner Retries";
+  private static final String SNOWFLAKE_CLEANER_RESTARTS_DEFAULT = "-1";
+
+
   // Where is Kafka hosted? self, confluent or any other in future.
   // By default it will be None since this is not enforced and only used for monitoring
   public static final String PROVIDER_CONFIG = "provider";
@@ -368,7 +373,17 @@ public class SnowflakeSinkConnectorConfig {
             DELIVERY_GUARANTEE_VALIDATOR,
             Importance.LOW,
             "Determines the ingest semantics for snowflake connector, currently support"
-                + " at-least-once and exactly-once delivery guarantees");
+                + " at-least-once and exactly-once delivery guarantees")
+        .define(
+            SNOWFLAKE_CLEANER_RESTARTS_CONFIG,
+            Type.INT,
+            SNOWFLAKE_CLEANER_RESTARTS_DEFAULT,
+            Importance.LOW,
+            "Number of times to retry a failed cleaner operation. Defaults to unbounded retries.",
+            CONNECTOR_CONFIG,
+            5,
+            ConfigDef.Width.NONE,
+            SNOWFLAKE_CLEANER_RESTARTS_DISPLAY);
   }
 
   public static class TopicToTableValidator implements ConfigDef.Validator {

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -89,9 +89,9 @@ public class SnowflakeSinkConnectorConfig {
   public static final String SNOWFLAKE_METADATA_ALL = "snowflake.metadata.all";
   public static final String SNOWFLAKE_METADATA_DEFAULT = "true";
 
-  private static final String SNOWFLAKE_CLEANER_RESTARTS_CONFIG = "snowflake.cleaner.retries";
-  private static final String SNOWFLAKE_CLEANER_RESTARTS_DISPLAY = "Snowflake Cleaner Retries";
-  private static final String SNOWFLAKE_CLEANER_RESTARTS_DEFAULT = "-1";
+  public static final String SNOWFLAKE_CLEANER_MAX_RETRIES_CONFIG = "snowflake.cleaner.retries";
+  public static final String SNOWFLAKE_CLEANER_MAX_RETRIES_DEFAULT = "-1";
+  private static final String SNOWFLAKE_CLEANER_MAX_RETRIES_DISPLAY = "Snowflake Cleaner Retries";
 
 
   // Where is Kafka hosted? self, confluent or any other in future.
@@ -375,15 +375,15 @@ public class SnowflakeSinkConnectorConfig {
             "Determines the ingest semantics for snowflake connector, currently support"
                 + " at-least-once and exactly-once delivery guarantees")
         .define(
-            SNOWFLAKE_CLEANER_RESTARTS_CONFIG,
+            SNOWFLAKE_CLEANER_MAX_RETRIES_CONFIG,
             Type.INT,
-            SNOWFLAKE_CLEANER_RESTARTS_DEFAULT,
+            SNOWFLAKE_CLEANER_MAX_RETRIES_DEFAULT,
             Importance.LOW,
             "Number of times to retry a failed cleaner operation. Defaults to unbounded retries.",
             CONNECTOR_CONFIG,
             5,
             ConfigDef.Width.NONE,
-            SNOWFLAKE_CLEANER_RESTARTS_DISPLAY);
+            SNOWFLAKE_CLEANER_MAX_RETRIES_DISPLAY);
   }
 
   public static class TopicToTableValidator implements ConfigDef.Validator {

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -134,6 +134,14 @@ public class SnowflakeSinkTask extends SinkTask {
               parsedConfig.get(SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG));
     }
 
+    final int maxCleanerRetries =
+            Integer.parseInt(
+                    parsedConfig.getOrDefault(
+                            SnowflakeSinkConnectorConfig.SNOWFLAKE_CLEANER_MAX_RETRIES_CONFIG,
+                            SnowflakeSinkConnectorConfig.SNOWFLAKE_CLEANER_MAX_RETRIES_DEFAULT
+                    )
+            );
+
     // we would have already validated the config inside SFConnector start()
     boolean enableCustomJMXMonitoring = SnowflakeSinkConnectorConfig.JMX_OPT_DEFAULT;
     if (parsedConfig.containsKey(SnowflakeSinkConnectorConfig.JMX_OPT)) {
@@ -167,6 +175,7 @@ public class SnowflakeSinkTask extends SinkTask {
             .setBehaviorOnNullValuesConfig(behavior)
             .setCustomJMXMetrics(enableCustomJMXMonitoring)
             .setDeliveryGuarantee(ingestionDeliveryGuarantee)
+            .setMaxCleanerRetries(maxCleanerRetries)
             .build();
 
     LOGGER.info(

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -127,7 +127,7 @@ public interface SnowflakeSinkService {
   void setCustomJMXMetrics(boolean enableJMX);
 
   /* Set the behavior on what action to perform when this( @see com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BEHAVIOR_ON_NULL_VALUES_CONFIG ) config is set. */
-  void setCleanerRetries(int retries);
+  void setMaxCleanerRetries(int retries);
 
 
   /* Only used in testing and verifying what was the passed value of this behavior from config to sink service*/

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -126,6 +126,10 @@ public interface SnowflakeSinkService {
   /* Should we emit Custom SF JMX Metrics to Mbean Server? If true (Default), we emit in form of SimpleMbeans */
   void setCustomJMXMetrics(boolean enableJMX);
 
+  /* Set the behavior on what action to perform when this( @see com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BEHAVIOR_ON_NULL_VALUES_CONFIG ) config is set. */
+  void setCleanerRetries(int retries);
+
+
   /* Only used in testing and verifying what was the passed value of this behavior from config to sink service*/
   SnowflakeSinkConnectorConfig.BehaviorOnNullValues getBehaviorOnNullValuesConfig();
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
@@ -90,6 +90,14 @@ public class SnowflakeSinkServiceFactory {
       return this;
     }
 
+    public SnowflakeSinkServiceBuilder setCleanerRetries(
+            int retries
+    ) {
+      this.service.setCleanerRetries(retries);
+      logInfo("set Cleaner Retries to {} \n", retries);
+      return this;
+    }
+
     public SnowflakeSinkService build() {
       logInfo("{} created", SnowflakeSinkService.class.getName());
       return service;

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
@@ -90,10 +90,10 @@ public class SnowflakeSinkServiceFactory {
       return this;
     }
 
-    public SnowflakeSinkServiceBuilder setCleanerRetries(
+    public SnowflakeSinkServiceBuilder setMaxCleanerRetries(
             int retries
     ) {
-      this.service.setCleanerRetries(retries);
+      this.service.setMaxCleanerRetries(retries);
       logInfo("set Cleaner Retries to {} \n", retries);
       return this;
     }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -19,7 +19,6 @@ import java.io.ObjectOutputStream;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -19,12 +19,15 @@ import java.io.ObjectOutputStream;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +42,9 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
   // Set in config (Time based flush) in seconds
   private long flushTime;
   // Set in config (buffer size based flush) in bytes
+  private static final int UNBOUNDED_CLEANER_RETRIES = -1;
+
+  private long flushTime; // in seconds
   private long fileSize;
 
   // Set in config (Threshold before we send the buffer to internal stage) corresponds to # of
@@ -50,9 +56,11 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
   private boolean isStopped;
   private final SnowflakeTelemetryService telemetryService;
   private Map<String, String> topic2TableMap;
+  private int cleanerRetries;
 
   // Behavior to be set at the start of connector start. (For tombstone records)
   private SnowflakeSinkConnectorConfig.BehaviorOnNullValues behaviorOnNullValues;
+  private AtomicReference<ConnectException> failedCleanerException;
 
   // default is true unless the configuration provided is false;
   // If this is true, we will enable Mbean for required classes and emit JMX metrics for monitoring
@@ -81,6 +89,7 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
     // Setting the default value in constructor
     // meaning it will not ignore the null values (Tombstone records wont be ignored/filtered)
     this.behaviorOnNullValues = SnowflakeSinkConnectorConfig.BehaviorOnNullValues.DEFAULT;
+    this.failedCleanerException = null;
   }
 
   @Override
@@ -98,6 +107,15 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
 
   @Override
   public void insert(final Collection<SinkRecord> records) {
+    ConnectException potentialEx = failedCleanerException.get();
+    if (potentialEx != null) {
+      for (ServiceContext pipe : pipes.values()) {
+        // flush current buffers
+        pipe.flushBuffer();
+      }
+      throw potentialEx;
+    }
+
     // note that records can be empty
     for (SinkRecord record : records) {
       // check if need to handle null value records
@@ -351,6 +369,12 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
   }
 
   @Override
+  public void setCleanerRetries(int num) {
+    this.cleanerRetries = num;
+  }
+
+
+  @Override
   public SnowflakeSinkConnectorConfig.BehaviorOnNullValues getBehaviorOnNullValuesConfig() {
     return this.behaviorOnNullValues;
   }
@@ -566,7 +590,13 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
                     e.getMessage(),
                     e.getStackTrace());
                 telemetryService.reportKafkaFatalError(e.getMessage());
-                forceCleanerFileReset = true;
+                if (cleanerRetries > 0) {
+                  cleanerRetries--;
+                  forceCleanerFileReset = true;
+                } else if(cleanerRetries == 0) {
+                  failedCleanerException.set(new ConnectException(e));
+                  break;
+                }
               }
             }
           });

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -86,7 +86,7 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
     // Setting the default value in constructor
     // meaning it will not ignore the null values (Tombstone records wont be ignored/filtered)
     this.behaviorOnNullValues = SnowflakeSinkConnectorConfig.BehaviorOnNullValues.DEFAULT;
-    this.failedCleanerException = null;
+    this.failedCleanerException = new AtomicReference<>();
   }
 
   @Override
@@ -588,12 +588,12 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
                     e.getMessage(),
                     e.getStackTrace());
                 telemetryService.reportKafkaFatalError(e.getMessage());
-                if (cleanerRetries > 0) {
-                  cleanerRetries--;
-                  forceCleanerFileReset = true;
-                } else if(cleanerRetries == 0) {
+                if (cleanerRetries == 0) {
                   failedCleanerException.set(e);
                   break;
+                } else if(cleanerRetries > 0) {
+                  cleanerRetries--;
+                  forceCleanerFileReset = true;
                 }
               }
             }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -53,7 +53,7 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
   private boolean isStopped;
   private final SnowflakeTelemetryService telemetryService;
   private Map<String, String> topic2TableMap;
-  private int cleanerRetries;
+  private int maxCleanerRetries;
 
   // Behavior to be set at the start of connector start. (For tombstone records)
   private SnowflakeSinkConnectorConfig.BehaviorOnNullValues behaviorOnNullValues;
@@ -367,8 +367,8 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
   }
 
   @Override
-  public void setCleanerRetries(int num) {
-    this.cleanerRetries = num;
+  public void setMaxCleanerRetries(int num) {
+    this.maxCleanerRetries = num;
   }
 
 
@@ -588,13 +588,11 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
                     e.getMessage(),
                     e.getStackTrace());
                 telemetryService.reportKafkaFatalError(e.getMessage());
-                if (cleanerRetries == 0) {
+                if (maxCleanerRetries >= 0 &&  pipeStatus.cleanerRestartCount.intValue() == maxCleanerRetries) {
                   failedCleanerException.set(e);
                   break;
-                } else if(cleanerRetries > 0) {
-                  cleanerRetries--;
-                  forceCleanerFileReset = true;
                 }
+                forceCleanerFileReset = true;
               }
             }
           });

--- a/src/test/java/com/snowflake/kafka/connector/internal/CleanerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/CleanerTest.java
@@ -38,7 +38,7 @@ public class CleanerTest {
                 SnowflakeSinkServiceFactory.builder(conn)
                         .setRecordNumber(1)
                         .addTask(table, topic, partition)
-                        .setCleanerRetries(0)
+                        .setMaxCleanerRetries(0)
                         .build();
         service.startTask(table, topic, partition);
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/CleanerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/CleanerTest.java
@@ -1,0 +1,60 @@
+package com.snowflake.kafka.connector.internal;
+
+import com.snowflake.kafka.connector.records.SnowflakeConverter;
+import com.snowflake.kafka.connector.records.SnowflakeJsonConverter;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.Test;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CleanerTest {
+    private final String table = TestUtils.randomTableName();
+    private final String topic = "test";
+
+    @Test(expected= ConnectException.class)
+    public void testCleanerFails() {
+
+        // throw error in cleaner thread
+        SnowflakeTelemetryService telemetryService = mock(SnowflakeTelemetryService.class);
+        doThrow(new RuntimeException("Error to stop Cleaner thread")).when(telemetryService).reportKafkaPipeUsage(any(), anyBoolean());
+
+
+        SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+        when(conn.getTelemetryClient()).thenReturn(telemetryService);
+
+        // set cleaner retries to 0
+        final int partition = 0;
+        SnowflakeSinkService service =
+                SnowflakeSinkServiceFactory.builder(conn)
+                        .setRecordNumber(1)
+                        .addTask(table, topic, partition)
+                        .setCleanerRetries(0)
+                        .build();
+        service.startTask(table, topic, partition);
+
+        SnowflakeConverter converter = new SnowflakeJsonConverter();
+        SchemaAndValue input =
+                converter.toConnectData(topic, "{\"name\":\"test\"}".getBytes(StandardCharsets.UTF_8));
+        long offset = 0;
+        SinkRecord record1 =
+                new SinkRecord(
+                        topic, partition, Schema.STRING_SCHEMA, "test", input.schema(), input.value(), offset);
+        // trigger cleaner failure
+        service.insert(Collections.singletonList(record1));
+        SinkRecord record2 =
+                new SinkRecord(
+                        topic, partition, Schema.STRING_SCHEMA, "test2", input.schema(), input.value(), offset);
+        // failed cleaner now should kill the task
+        service.insert(Collections.singletonList(record2));
+    }
+}


### PR DESCRIPTION
Signed-off-by: SajanaW <sweerawardhena@confluent.io>

### Problem

Every Snowflake task spins up a cleaner thread. By design, every record is written to an internal stage and then it signals to a corresponding Snow pipe that this file should be ingested. The cleaner thread then tracks the written file on the stage and the corresponding ingestion job- and after Snow pipe has successfully ingested the file, the cleaner will delete the file. 

In other words, a sink operation to snowflake is not-atomic and could fail after it is written to the stage but BEFORE it's ingested by Snow pipe. When this happens this connector does not kill the task: it continues to write to the stage and the cleaner continues to retry. 

In the best case, this confuses the customer because the connector continues to work without failing. https://confluentinc.atlassian.net/browse/RCCA-6372

In the worst case, this could build up a huge backlog on the stage so that when we read the filenames from the stage - it fills up a list to a huge number of nodes (21 M for example) which kills heap space. See: https://confluentinc.atlassian.net/browse/RCCA-5928 


### Solution

In order to bubble up the right message to the customer we should just kill the task when we encounter an issue with moving data from the internal stage to SNOW PIPE. 

The main concern here is that we've already committed offsets for the records which have failed to move to SNOW PIPE. However since we load files from the stage and clean up based on their ingestion report - we are effectively still not losing data (it's persisted in the stage). 


