### PR TITLE
CCDB-5252: add login time for snowflake connection validation

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -269,8 +269,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
               result, Utils.SF_PRIVATE_KEY, " must be a valid PEM RSA private key");
           break;
         default:
-          Utils.updateConfigErrorMessage(result, Utils.SF_PRIVATE_KEY, "network is the because");
-          //throw e; // Shouldn't reach here, so crash.
+          throw e; // Shouldn't reach here, so crash.
       }
       return result;
     }

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -61,6 +61,8 @@ public class SnowflakeSinkConnector extends SinkConnector {
 
   private int VALIDATION_NETWORK_TIMEOUT = 45000;
 
+  private int LOGIN_VALIDATION_NETWORK_TIMEOUT_IN_SEC = 20;
+
   /** No-Arg constructor. Required by Kafka Connect framework */
   public SnowflakeSinkConnector() {
     setupComplete = false;
@@ -236,6 +238,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
           SnowflakeConnectionServiceFactory.builder()
                   .setProperties(connectorConfigs)
                   .setNetworkTimeout(VALIDATION_NETWORK_TIMEOUT)
+                  .setLoginTimeOut(LOGIN_VALIDATION_NETWORK_TIMEOUT_IN_SEC)
                   .build();
 
     } catch (SnowflakeKafkaConnectorException e) {
@@ -266,7 +269,8 @@ public class SnowflakeSinkConnector extends SinkConnector {
               result, Utils.SF_PRIVATE_KEY, " must be a valid PEM RSA private key");
           break;
         default:
-          throw e; // Shouldn't reach here, so crash.
+          Utils.updateConfigErrorMessage(result, Utils.SF_PRIVATE_KEY, "network is the because");
+          //throw e; // Shouldn't reach here, so crash.
       }
       return result;
     }

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -59,9 +59,9 @@ public class SnowflakeSinkConnector extends SinkConnector {
   // Using setupComplete to synchronize
   private boolean setupComplete;
 
-  private int VALIDATION_NETWORK_TIMEOUT = 45000;
+  private static final int VALIDATION_NETWORK_TIMEOUT = 45000;
 
-  private int LOGIN_VALIDATION_NETWORK_TIMEOUT_IN_SEC = 20;
+  private static final int LOGIN_VALIDATION_NETWORK_TIMEOUT_IN_SEC = 20;
 
   /** No-Arg constructor. Required by Kafka Connect framework */
   public SnowflakeSinkConnector() {

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -59,7 +59,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
   // Using setupComplete to synchronize
   private boolean setupComplete;
 
-  private static final int VALIDATION_NETWORK_TIMEOUT = 45000;
+  private static final int VALIDATION_NETWORK_TIMEOUT_IN_MS = 45000;
 
   private static final int VALIDATION_LOGIN_TIMEOUT_IN_SEC = 20;
 
@@ -237,7 +237,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
       testConnection =
           SnowflakeConnectionServiceFactory.builder()
                   .setProperties(connectorConfigs)
-                  .setNetworkTimeout(VALIDATION_NETWORK_TIMEOUT)
+                  .setNetworkTimeout(VALIDATION_NETWORK_TIMEOUT_IN_MS)
                   .setLoginTimeOut(VALIDATION_LOGIN_TIMEOUT_IN_SEC)
                   .build();
 

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -61,7 +61,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
 
   private static final int VALIDATION_NETWORK_TIMEOUT = 45000;
 
-  private static final int LOGIN_VALIDATION_NETWORK_TIMEOUT_IN_SEC = 20;
+  private static final int VALIDATION_LOGIN_TIMEOUT_IN_SEC = 20;
 
   /** No-Arg constructor. Required by Kafka Connect framework */
   public SnowflakeSinkConnector() {
@@ -238,7 +238,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
           SnowflakeConnectionServiceFactory.builder()
                   .setProperties(connectorConfigs)
                   .setNetworkTimeout(VALIDATION_NETWORK_TIMEOUT)
-                  .setLoginTimeOut(LOGIN_VALIDATION_NETWORK_TIMEOUT_IN_SEC)
+                  .setLoginTimeOut(VALIDATION_LOGIN_TIMEOUT_IN_SEC)
                   .build();
 
     } catch (SnowflakeKafkaConnectorException e) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -31,6 +31,8 @@ class InternalUtils {
   static final String JDBC_WAREHOUSE = "warehouse"; // for test only
   static final String JDBC_NETWORK_TIMEOUT = "networkTimeout";
 
+  static final String JDBC_LOGIN_TIMEOUT = "loginTimeout";
+
   // internal parameters
   static final long MAX_RECOVERY_TIME = 10 * 24 * 3600 * 1000; // 10 days
 
@@ -114,7 +116,7 @@ class InternalUtils {
    * @param sslEnabled if ssl is enabled
    * @return a Properties instance
    */
-  static Properties createProperties(Map<String, String> conf, boolean sslEnabled, int networkTimeout) {
+  static Properties createProperties(Map<String, String> conf, boolean sslEnabled, int networkTimeout, int loginTimeout) {
     Properties properties = new Properties();
 
     // decrypt rsa key
@@ -165,6 +167,11 @@ class InternalUtils {
     if (networkTimeout != 0) {
       properties.put(JDBC_NETWORK_TIMEOUT, networkTimeout);
     }
+
+    if(loginTimeout != 0) {
+      properties.put(JDBC_LOGIN_TIMEOUT, loginTimeout);
+    }
+
     // put values for optional parameters
     properties.put(JDBC_SESSION_KEEP_ALIVE, "true");
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
@@ -22,6 +22,10 @@ public class SnowflakeConnectionServiceFactory {
     // https://docs.snowflake.com/en/user-guide/jdbc-parameters.html#networktimeout
     private int networkTimeOut = 0;
 
+    // loginTimeOut is defined in secs
+    // https://docs.snowflake.com/en/user-guide/jdbc-parameters.html#logintimeout
+    private int loginTimeOut = 60;
+
     // whether kafka is hosted on premise or on confluent cloud.
     // This info is provided in the connector configuration
     // This property will be appeneded to user agent while calling snowpipe API in http request
@@ -58,12 +62,17 @@ public class SnowflakeConnectionServiceFactory {
       return this;
     }
 
+    public SnowflakeConnectionServiceBuilder setLoginTimeOut(int timeout) {
+      this.loginTimeOut = timeout;
+      return this;
+    }
+
     public SnowflakeConnectionServiceBuilder setProperties(Map<String, String> conf) {
       if (!conf.containsKey(Utils.SF_URL)) {
         throw SnowflakeErrors.ERROR_0017.getException();
       }
       this.url = new SnowflakeURL(conf.get(Utils.SF_URL));
-      this.prop = InternalUtils.createProperties(conf, this.url.sslEnabled(), this.networkTimeOut);
+      this.prop = InternalUtils.createProperties(conf, this.url.sslEnabled(), this.networkTimeOut, this.loginTimeOut);
       this.kafkaProvider =
           SnowflakeSinkConnectorConfig.KafkaProvider.of(conf.get(PROVIDER_CONFIG)).name();
       // TODO: Ideally only one property is required, but because we dont pass it around in JDBC and

--- a/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
@@ -99,7 +99,7 @@ public class ConnectionServiceIT {
         });
 
     SnowflakeURL url = TestUtils.getUrl();
-    Properties prop = InternalUtils.createProperties(TestUtils.getConf(), url.sslEnabled(), 0);
+    Properties prop = InternalUtils.createProperties(TestUtils.getConf(), url.sslEnabled(), 0, 60);
     String appName = TestUtils.TEST_CONNECTOR_NAME;
 
     SnowflakeConnectionServiceFactory.builder()

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
@@ -78,7 +78,7 @@ public class InternalUtilsTest {
   public void testCreateProperties() {
     Map<String, String> config = TestUtils.getConf();
     SnowflakeURL url = TestUtils.getUrl();
-    Properties prop = InternalUtils.createProperties(config, url.sslEnabled(), 0);
+    Properties prop = InternalUtils.createProperties(config, url.sslEnabled(), 0, 60);
     assert prop.containsKey(InternalUtils.JDBC_DATABASE);
     assert prop.containsKey(InternalUtils.JDBC_PRIVATE_KEY);
     assert prop.containsKey(InternalUtils.JDBC_SCHEMA);
@@ -99,7 +99,7 @@ public class InternalUtilsTest {
         () -> {
           Map<String, String> t = new HashMap<>(config);
           t.remove(Utils.SF_PRIVATE_KEY);
-          InternalUtils.createProperties(t, url.sslEnabled(), 0);
+          InternalUtils.createProperties(t, url.sslEnabled(), 0, 60);
         });
 
     assert TestUtils.assertError(
@@ -107,7 +107,7 @@ public class InternalUtilsTest {
         () -> {
           Map<String, String> t = new HashMap<>(config);
           t.remove(Utils.SF_SCHEMA);
-          InternalUtils.createProperties(t, url.sslEnabled(), 0);
+          InternalUtils.createProperties(t, url.sslEnabled(), 0, 60);
         });
 
     assert TestUtils.assertError(
@@ -115,7 +115,7 @@ public class InternalUtilsTest {
         () -> {
           Map<String, String> t = new HashMap<>(config);
           t.remove(Utils.SF_DATABASE);
-          InternalUtils.createProperties(t, url.sslEnabled(), 0);
+          InternalUtils.createProperties(t, url.sslEnabled(), 0, 60);
         });
 
     assert TestUtils.assertError(
@@ -123,7 +123,7 @@ public class InternalUtilsTest {
         () -> {
           Map<String, String> t = new HashMap<>(config);
           t.remove(Utils.SF_USER);
-          InternalUtils.createProperties(t, url.sslEnabled(), 0);
+          InternalUtils.createProperties(t, url.sslEnabled(), 0, 60);
         });
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -127,7 +127,7 @@ public class TestUtils {
 
     SnowflakeURL url = new SnowflakeURL(getConf().get(Utils.SF_URL));
 
-    Properties properties = InternalUtils.createProperties(getConf(), url.sslEnabled(), 0);
+    Properties properties = InternalUtils.createProperties(getConf(), url.sslEnabled(), 0, 60);
 
     conn = new SnowflakeDriver().connect(url.getJdbcUrl(), properties);
 


### PR DESCRIPTION
### Problem
We're running into a number of issues in production where  Snowflake connection calls takes more time than the gate way time out for validate calls, which leads to gate way time out errors (504) for those calls, which leads to an ominous error message on the UI: ANUNKNOWN ERROR OCCURED.

gateway timeout = 30 sec

snowflake driver default connection/login time out  = 60 sec

### Solution
Put a login time out less than 30 sec (20 sec in this case) for snowflake driver
