### PR TITLE
Bump snowflake jdbc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.13.3</version>
+            <version>3.13.30</version>
         </dependency>
 
         <!--junit for unit test-->

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -449,7 +449,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.13.3</version>
+            <version>3.13.30</version>
         </dependency>
 
         <!--junit for unit test-->

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -5,14 +5,13 @@ import static com.snowflake.kafka.connector.Utils.TASK_ID;
 import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
 import static com.snowflake.kafka.connector.internal.TestUtils.getConf;
 
-import com.snowflake.kafka.connector.internal.TestUtils;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
+
+import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigValue;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -98,15 +97,6 @@ public class ConnectorIT {
     config.remove(Utils.NAME);
     config.remove(TASK_ID);
     return config;
-  }
-
-  @After
-  public void cleanup() throws SnowflakeSQLException {
-    try {
-      TestUtils.resetProxyParametersInJDBC();
-    } catch (SnowflakeSQLException ex) {
-      Assert.fail("Cannot reset proxy parameters in:" + this.getClass().getName());
-    }
   }
 
   @Test
@@ -280,8 +270,7 @@ public class ConnectorIT {
     Map<String, String> config = getCorrectConfig();
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST, "localhost");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "8080");
-    Map<String, ConfigValue> validateMap = toValidateMap(config);
-    assertPropHasError(validateMap, new String[] {});
+    Utils.validateProxySetting(config);
   }
 
   @Test
@@ -290,13 +279,13 @@ public class ConnectorIT {
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST, "localhost");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "8080");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME, "user");
-    Map<String, ConfigValue> validateMap = toValidateMap(config);
-    assertPropHasError(
-        validateMap,
-        new String[] {
-          SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME,
-          SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD
-        });
+    try {
+      Utils.validateProxySetting(config);
+    } catch (SnowflakeKafkaConnectorException e) {
+      Assert.assertEquals("0023", e.getCode());
+      return;
+    }
+    Assert.fail();
   }
 
   @Test
@@ -305,13 +294,13 @@ public class ConnectorIT {
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST, "localhost");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "8080");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD, "pass");
-    Map<String, ConfigValue> validateMap = toValidateMap(config);
-    assertPropHasError(
-        validateMap,
-        new String[] {
-          SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME,
-          SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD
-        });
+    try {
+      Utils.validateProxySetting(config);
+    } catch (SnowflakeKafkaConnectorException e) {
+      Assert.assertEquals("0023", e.getCode());
+      return;
+    }
+    Assert.fail();
   }
 
   @Test
@@ -321,8 +310,7 @@ public class ConnectorIT {
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "3128");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME, "admin");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD, "test");
-    Map<String, ConfigValue> validateMap = toValidateMap(config);
-    assertPropHasError(validateMap, new String[] {});
+    Utils.validateProxySetting(config);
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -14,12 +13,7 @@ public class SinkTaskProxyIT {
 
   @After
   public void testCleanup() {
-    try {
-      TestUtils.resetProxyParametersInJDBC();
-      TestUtils.resetProxyParametersInJVM();
-    } catch (SnowflakeSQLException ex) {
-      Assert.fail("Cannot reset proxy parameters in:" + this.getClass().getName());
-    }
+    TestUtils.resetProxyParametersInJVM();
   }
 
   @Test(expected = SnowflakeKafkaConnectorException.class)

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalStageIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalStageIT.java
@@ -165,9 +165,6 @@ public class InternalStageIT {
     assert files1.size() == 2;
     System.out.println(Logging.logMessage("Time: {} ms", (System.currentTimeMillis() - startTime)));
     proxyConnectionService.dropStage(proxyStage);
-
-    // Reset proxy configuration
-    TestUtils.resetProxyParametersInJDBC();
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/internal/ResetProxyConfigExec.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/ResetProxyConfigExec.java
@@ -5,7 +5,6 @@ import net.snowflake.client.jdbc.SnowflakeSQLException;
 public class ResetProxyConfigExec extends Logging {
   public static void main(String[] args) throws SnowflakeSQLException {
     System.out.println("ResetProxyConfigExec::Start wiping Proxy config");
-    TestUtils.resetProxyParametersInJDBC();
     TestUtils.resetProxyParametersInJVM();
     System.out.println("ResetProxyConfigExec::Proxy Parameters reset in JVM in JDBC");
   }

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -282,7 +282,7 @@ public class TestUtils {
   public static void resetProxyParametersInJDBC() throws SnowflakeSQLException {
     Map<SFSessionProperty, Object> resetProxy = new EnumMap(SFSessionProperty.class);
     resetProxy.put(SFSessionProperty.USE_PROXY, false);
-    HttpUtil.configureCustomProxyProperties(resetProxy);
+//    HttpUtil.configureCustomProxyProperties(resetProxy);
   }
 
   /**

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -30,9 +30,6 @@ import java.sql.Statement;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import net.snowflake.client.core.HttpUtil;
-import net.snowflake.client.core.SFSessionProperty;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
 
@@ -272,17 +269,6 @@ public class TestUtils {
    */
   public static SnowflakeConnectionService getConnectionService(Map<String, String> configuration) {
     return SnowflakeConnectionServiceFactory.builder().setProperties(configuration).build();
-  }
-
-  /**
-   * Reset proxy parameters in JDBC. JDBC's useProxy parameter is static member, needs to be reset
-   * after every test run. i.e needs to run after every new connection is set which modifies the
-   * proxy parameter.
-   */
-  public static void resetProxyParametersInJDBC() throws SnowflakeSQLException {
-    Map<SFSessionProperty, Object> resetProxy = new EnumMap(SFSessionProperty.class);
-    resetProxy.put(SFSessionProperty.USE_PROXY, false);
-//    HttpUtil.configureCustomProxyProperties(resetProxy);
   }
 
   /**


### PR DESCRIPTION
Updating `snowflake-jdbc` dependency to `3.13.30`.  The current dependency has a logic which suppresses the JVM Illegal Access Warn logs. The new version gives an option to disable it. These changes are part of https://github.com/snowflakedb/snowflake-jdbc/issues/1270