### PR TITLE
RCCA-11968: Make Avro converter and serializer provided dependecies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,7 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
             <version>7.2.1</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>io.confluent</groupId>
@@ -393,6 +394,7 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-avro-converter</artifactId>
             <version>7.2.1</version>
+            <scope>provided</scope>
         </dependency>
 
         <!--JDBC driver for building connection with Snowflake-->

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -432,6 +432,7 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
             <version>7.2.1</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>io.confluent</groupId>
@@ -444,6 +445,7 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-avro-converter</artifactId>
             <version>7.2.1</version>
+            <scope>provided</scope>
         </dependency>
 
         <!--JDBC driver for building connection with Snowflake-->


### PR DESCRIPTION
See https://confluent.slack.com/archives/C052MMCNP7U/p1685697815724809?thread_ts=1685697149.382079&cid=C052MMCNP7U

Snowflake connector packages Avro converter and serializer. However, this means when using the AVRO data format, the connector would end up loading packaged dependencies rather than the one in the classpath.

In the confluent cloud, we have converters and serializers patched for bugfixes and those changes don't take up. While one idea is to update the version, however it seems an antipattern to package the converter and can cause unwanted issues during different pipelines.