### PR TITLE
ASA-906 Fix ReDOS Vulnerability

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -167,8 +167,9 @@ public class Utils {
       InputStream input = urlConnection.getInputStream();
       BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(input));
       String line;
-      Pattern pattern = Pattern.compile("(\\d+\\.\\d+\\.\\d+?)");
+      Pattern pattern = Pattern.compile("(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}?)"); // Secure Regex
       while ((line = bufferedReader.readLine()) != null) {
+        line = line.substring(0, Math.min(line.length(), 1000)); // Limit regex input to 1000 chars to prevent ReDOS
         Matcher matcher = pattern.matcher(line);
         if (matcher.find()) {
           String version = matcher.group(1);


### PR DESCRIPTION
**ReDOS in Java :** https://codeql.github.com/codeql-query-help/java/java-polynomial-redos/

Typically, a regular expression is affected by this problem if it contains a repetition of the form r* or r+ where the sub-expression r is ambiguous in the sense that it can match some string in multiple ways

Example 1: Long Input of the form 1*n.2.33 causes Regex time-out , where n is large
<img width="1439" alt="Screenshot 2023-12-13 at 4 51 50 PM" src="https://github.com/confluentinc/snowflake-kafka-connector/assets/76967544/55cd77ca-f9c4-486e-a631-2f00802604b2">

Example 2: Long Input of the form 1*n.2.33 matches secure Regex without time-out , where n is large
<img width="1437" alt="Screenshot 2023-12-13 at 4 50 09 PM" src="https://github.com/confluentinc/snowflake-kafka-connector/assets/76967544/3b5f55a0-4687-47cc-932b-c3a67b19f366">