### PR TITLE
Lower dependency count

### DIFF
--- a/scripts/process_licenses.py
+++ b/scripts/process_licenses.py
@@ -146,7 +146,7 @@ def main():
     with open(Path(target_dir, "ADDITIONAL_LICENCES"), "w") as additional_licenses_handle:
         additional_licenses_handle.write(missing_licenses_str)
 
-    if dependency_count < 30:
+    if dependency_count < 25:
         raise Exception(f"Suspiciously low number of dependency JARs detected in {dependency_jars_path}: {dependency_count}")
     print("License generation finished")
     print(f"\tTotal dependencies: {dependency_count}")


### PR DESCRIPTION
Current build fails with 
```
  File "/home/semaphore/connect-releases/tasks/release-connect-plugins/snowflake-kafka-connector/scripts/process_licenses.py", line 150, in main
    raise Exception(f"Suspiciously low number of dependency JARs detected in {dependency_jars_path}: {dependency_count}")
Exception: Suspiciously low number of dependency JARs detected in /home/semaphore/connect-releases/tasks/release-connect-plugins/snowflake-kafka-connector/target/dependency-jars:
```
Originating from `scripts/process_licenses.py`.

Comparing jars packaged in 2.2.x (fork)  v/s v2.2.2 (upstream) 
<img width="1290" alt="Screenshot 2024-06-01 at 2 25 44 PM" src="https://github.com/confluentinc/snowflake-kafka-connector/assets/67974618/cbfbdaad-733a-44ac-8f78-cf157b539c48">

Confluent code has explicitly marked `kafka-connect-avro*` + `kafka-schema-*` (and transitive dependencies) as `provided` scope - https://github.com/confluentinc/snowflake-kafka-connector/pull/37. 

Hence decreasing the expected dependencies in package. 
