### PR TITLE
Add schema table privilege check

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -33,6 +33,8 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
+
 /**
  * SnowflakeSinkConnector implements SinkConnector for Kafka Connect framework.
  *
@@ -306,8 +308,51 @@ public class SnowflakeSinkConnector extends SinkConnector {
       return result;
     }
 
+    try {
+      testConnection.hasSchemaPrivileges(connectorConfigs.get(Utils.SF_SCHEMA),
+              connectorConfigs.getOrDefault(INGESTION_METHOD_OPT, "SNOWPIPE"));
+    } catch (SnowflakeKafkaConnectorException e) {
+      LOGGER.error("Validate Error msg:{}, errorCode:{}", e.getMessage(), e.getCode());
+      if (e.getCode().equals("2001")) {
+        LOGGER.error(Utils.SF_SCHEMA + ": provided role does not have one of the required privileges "
+                + "(CREATE TABLE, CREATE STAGE, CREATE PIPE) on the schema");
+      }
+    } catch (Exception e) {
+      LOGGER.error("Unexpected Exception in validate for schema privilege check msg:{}, errorCode:{}", e.getMessage(), e);
+    }
+
+    if (shouldCheckTablePrivilege(connectorConfigs)) {
+      Map<String, String> topicsTablesMap = Utils.parseTopicToTableMap(connectorConfigs.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP));
+      if (topicsTablesMap != null) {
+        checkTablePrivilege(topicsTablesMap, testConnection);
+      }
+    }
+
     LOGGER.info("Validated config with no error");
     return result;
+  }
+
+  private static boolean shouldCheckTablePrivilege(Map<String, String> connectorConfigs) {
+    String topicsTablesMap = connectorConfigs.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP);
+    return topicsTablesMap != null && !topicsTablesMap.isEmpty();
+  }
+
+  private static void checkTablePrivilege(Map<String, String> topicsTablesMap, SnowflakeConnectionService testConnection) {
+    topicsTablesMap.forEach((topic, table) -> {
+      try {
+        if (testConnection.tableExist(table)) {
+          LOGGER.info("Table already {} exists, checking if we sufficient privileges", table);
+          testConnection.hasTableRequiredPrivileges(table);
+        }
+      } catch (SnowflakeKafkaConnectorException e) {
+        LOGGER.error("Validation Error for table {}: msg:{}, errorCode:{}", table, e.getMessage(), e.getCode());
+        if (e.getCode().equals("2001")) {
+          LOGGER.error(table, " Table does not have the required OWNERSHIP privilege");
+        }
+      } catch (Exception e) {
+        LOGGER.error("Unexpected Exception in validate for table privilege check {}: msg:{}, errorCode:{}", table, e.getMessage(), e);
+      }
+    });
   }
 
   private static boolean isUsingConfigProvider(Map<String, String> connectorConfigs) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -150,6 +150,10 @@ public interface SnowflakeConnectionService {
    */
   void schemaExists(String schemaName);
 
+  void hasSchemaPrivileges(String schemaName, String ingestionMethod);
+
+  void hasTableRequiredPrivileges(String tableName);
+
   /**
    * drop snowpipe
    *

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -21,7 +21,12 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.*;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import net.snowflake.client.jdbc.SnowflakeConnectionV1;
 import net.snowflake.client.jdbc.SnowflakeDriver;
@@ -676,6 +681,129 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
   }
 
   @Override
+  public void hasSchemaPrivileges(String schemaName, String ingestionMethod) {
+    checkConnection();
+    String queryUseSchema = "USE SCHEMA IDENTIFIER(?)";
+    String queryCheckPrivileges = "SHOW GRANTS ON SCHEMA " + schemaName + ";";
+    String currentRole = getCurrentRole(conn);
+
+    boolean hasOwnershipPrivilege = false;
+    boolean hasAllPrivilege = false;
+    boolean hasCreateTablePrivilege = false;
+    boolean hasCreateStagePrivilege = false;
+    boolean hasCreatePipePrivilege = false;
+
+    try {
+      PreparedStatement stmt = conn.prepareStatement(queryUseSchema);
+      stmt.setString(1, schemaName);
+      stmt.execute();
+      stmt.close();
+
+      stmt = conn.prepareStatement(queryCheckPrivileges);
+      ResultSet rs = stmt.executeQuery();
+      while (rs.next()) {
+        if (!rs.getString("grantee_name").equals(currentRole)) {
+          continue;
+        }
+        String privilege = rs.getString("privilege");
+        if (privilege.equalsIgnoreCase("OWNERSHIP")) {
+          hasOwnershipPrivilege = true;
+          break;
+        }
+        if (privilege.equalsIgnoreCase("ALL")) {
+          hasAllPrivilege = true;
+          break;
+        }
+        if (privilege.equalsIgnoreCase("CREATE TABLE")) {
+          hasCreateTablePrivilege = true;
+        }
+        if (privilege.equalsIgnoreCase("CREATE STAGE")) {
+          hasCreateStagePrivilege = true;
+        }
+        if (privilege.equalsIgnoreCase("CREATE PIPE")) {
+          hasCreatePipePrivilege = true;
+        }
+      }
+      rs.close();
+      stmt.close();
+
+      if (hasOwnershipPrivilege || hasAllPrivilege) {
+        LOGGER.info("Schema {} has required privileges", schemaName);
+        return;
+      }
+
+      if (!hasCreateTablePrivilege) {
+        throw SnowflakeErrors.ERROR_2001.getException("Missing CREATE TABLE privilege on schema " + schemaName);
+      }
+
+      if(ingestionMethod.equalsIgnoreCase(IngestionMethodConfig.SNOWPIPE_STREAMING.toString())) {
+        LOGGER.info("Schema {} has required privileges for SNOWPIPE_STREAMING ingestion", schemaName);
+        return;
+      }
+
+      // For SNOWPIPE ingestion, we need CREATE STAGE and CREATE PIPE privileges as well
+      if (!hasCreateStagePrivilege) {
+        throw SnowflakeErrors.ERROR_2001.getException("Missing CREATE STAGE privilege on schema " + schemaName);
+      }
+      if (!hasCreatePipePrivilege) {
+        throw SnowflakeErrors.ERROR_2001.getException("Missing CREATE PIPE privilege on schema " + schemaName);
+      }
+
+      LOGGER.info("Schema {} has required privileges", schemaName);
+
+    } catch (SQLException e) {
+      throw SnowflakeErrors.ERROR_2001.getException(e);
+    }
+  }
+
+  @Override
+  public void hasTableRequiredPrivileges(String tableName) {
+    checkConnection();
+    String queryCheckTablePrivileges = "SHOW GRANTS ON TABLE " + tableName + ";";
+    String currentRole = getCurrentRole(conn);
+    boolean hasOwnershipPrivilege = false;
+    boolean hasAllPrivileges = false;
+    boolean hasInsertPrivilege = false;
+
+    try {
+      PreparedStatement stmt = conn.prepareStatement(queryCheckTablePrivileges);
+      ResultSet rs = stmt.executeQuery();
+      while (rs.next()) {
+        if (!rs.getString("grantee_name").equals(currentRole)) {
+          continue;
+        }
+        String privilege = rs.getString("privilege");
+        if (privilege.equalsIgnoreCase("OWNERSHIP")) {
+          hasOwnershipPrivilege = true;
+          break;
+        }
+        if (privilege.equalsIgnoreCase("ALL")) {
+          hasAllPrivileges = true;
+        }
+        if (privilege.equalsIgnoreCase("INSERT")) {
+          hasInsertPrivilege = true;
+        }
+      }
+      rs.close();
+      stmt.close();
+
+      if (hasOwnershipPrivilege || hasAllPrivileges) {
+        LOGGER.info("Table {} has either OWNERSHIP or ALL privileges", tableName);
+        return;
+      }
+
+      if (!hasInsertPrivilege) { // only checking the bare minimum privilege we need
+        throw SnowflakeErrors.ERROR_2001.getException("Missing INSERT privilege on table " + tableName);
+      }
+
+      LOGGER.info("Table {} has required privilege", tableName);
+
+    } catch (SQLException e) {
+      throw SnowflakeErrors.ERROR_2001.getException(e);
+    }
+  }
+
+  @Override
   public void dropPipe(final String pipeName) {
     checkConnection();
     InternalUtils.assertNotEmpty("pipeName", pipeName);
@@ -1093,4 +1221,24 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
             migrateOffsetTokenResultFromSysFunc, ChannelMigrateOffsetTokenResponseDTO.class);
     return channelMigrateOffsetTokenResponseDTO;
   }
+
+  private String getCurrentRole(Connection conn) {
+    String query = "SELECT CURRENT_ROLE()";
+    String currentRole = null;
+    try {
+      Statement stmt = conn.createStatement();
+      ResultSet rs = stmt.executeQuery(query);
+      if (rs.next()) {
+        currentRole = rs.getString(1);
+      }
+    } catch (SQLException e) {
+      throw SnowflakeErrors.ERROR_2001.getException("Failed to fetch the current role");
+    }
+    if (currentRole == null) {
+      throw SnowflakeErrors.ERROR_2001.getException("Got current role as null");
+    }
+
+    return currentRole;
+  }
+
 }


### PR DESCRIPTION
Add schema privilege checks on stage, table and pipe depending on the ingestionMethod.
Add ownership privilege check on mapped tables which exists.

This PR only logs the errors, and not throw anything.