### PR TITLE
SNOW-1642799: added exception handler when moving invalid file to table stage; file cleaner will preserve 'dirty' files a bit longer

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -127,6 +127,15 @@ public class SnowflakeSinkConnectorConfig {
   public static final boolean SNOWPIPE_FILE_CLEANER_FIX_ENABLED_DEFAULT = false;
   public static final int SNOWPIPE_FILE_CLEANER_THREADS_DEFAULT = 1;
 
+  public static final String SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED =
+      "snowflake.snowpipe.stageFileNameExtensionEnabled";
+  public static final boolean SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED_DEFAULT = true;
+
+  // Whether to close streaming channels in parallel.
+  public static final String SNOWPIPE_STREAMING_CLOSE_CHANNELS_IN_PARALLEL =
+      "snowflake.streaming.closeChannelsInParallel.enabled";
+  public static final boolean SNOWPIPE_STREAMING_CLOSE_CHANNELS_IN_PARALLEL_DEFAULT = true;
+
   // This is the streaming max client lag which can be defined in config
   public static final String SNOWPIPE_STREAMING_MAX_CLIENT_LAG =
       "snowflake.streaming.max.client.lag";
@@ -573,6 +582,16 @@ public class SnowflakeSinkConnectorConfig {
             Importance.LOW,
             "Defines number of worker threads to associate with the cleaner task. By default there"
                 + " is one cleaner per topic's partition and they all share one worker thread")
+        .define(
+            SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED,
+            ConfigDef.Type.BOOLEAN,
+            SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED_DEFAULT,
+            ConfigDef.Importance.LOW,
+            "Defines whether stage file names should be prefixed with source topic's name hash."
+                + " This is required in scenarios, when there are multiple topics configured to"
+                + " ingest data into a single table via topic2table map. If disabled, there is a"
+                + " risk that files from various topics may collide with each other and be deleted"
+                + " before ingestion.")
         .define(
             SNOWPIPE_STREAMING_MAX_CLIENT_LAG,
             Type.LONG,

--- a/src/main/java/com/snowflake/kafka/connector/config/TopicToTableModeExtractor.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/TopicToTableModeExtractor.java
@@ -1,0 +1,37 @@
+package com.snowflake.kafka.connector.config;
+
+import com.snowflake.kafka.connector.Utils;
+import java.util.Map;
+
+public class TopicToTableModeExtractor {
+
+  /** Defines whether single target table is fed by one or many source topics. */
+  public enum Topic2TableMode {
+    // Single topic = single table
+    SINGLE_TOPIC_SINGLE_TABLE,
+    // Multiple topics = single table
+    MANY_TOPICS_SINGLE_TABLE,
+  }
+
+  private TopicToTableModeExtractor() {}
+
+  /**
+   * Util method - checks if given topic is defined in topic2Table map - if it is more than once, it
+   * means multiple topics will store data in single table - in such case, for SNOWPIPE ingestion we
+   * need to uniquely identify stage files so different instances of file cleaner won't handle
+   * other's channel files.
+   *
+   * @param topic
+   * @return
+   */
+  public static Topic2TableMode determineTopic2TableMode(
+      Map<String, String> topic2TableMap, String topic) {
+    String tableName = Utils.tableName(topic, topic2TableMap);
+    return topic2TableMap.values().stream()
+                .filter(table -> table.equalsIgnoreCase(tableName))
+                .count()
+            > 1
+        ? Topic2TableMode.MANY_TOPICS_SINGLE_TABLE
+        : Topic2TableMode.SINGLE_TOPIC_SINGLE_TABLE;
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
@@ -72,6 +72,19 @@ public class SnowflakeSinkServiceFactory {
         if (useStageFilesProcessor) {
           svc.enableStageFilesProcessor(threadCount);
         }
+
+        boolean extendedStageFileNameFix =
+            SnowflakeSinkConnectorConfig.SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED_DEFAULT;
+        if (connectorConfig != null
+            && connectorConfig.containsKey(
+                SnowflakeSinkConnectorConfig.SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED)) {
+          extendedStageFileNameFix =
+              Boolean.parseBoolean(
+                  connectorConfig.get(
+                      SnowflakeSinkConnectorConfig
+                          .SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED));
+        }
+        svc.configureSingleTableLoadFromMultipleTopics(extendedStageFileNameFix);
       } else {
         this.service = new SnowflakeSinkServiceV2(conn, connectorConfig);
       }

--- a/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
@@ -98,7 +98,8 @@ public class SinkTaskProxyIT {
     SnowflakeIngestionService ingestionService = connectionService.buildIngestService(stage, pipe);
 
     String file = "{\"aa\":123}";
-    String fileName = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, 0, 0, 1);
+    String fileName =
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 1);
 
     connectionService.putWithCache(stage, fileName, file);
     ingestionService.ingestFile(fileName);

--- a/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
@@ -44,6 +44,7 @@ public class ConnectionServiceIT {
   private final String pipeName = TestUtils.randomPipeName();
   private final String tableName1 = TestUtils.randomTableName();
   private final String stageName1 = TestUtils.randomStageName();
+  private final String topicName = TestUtils.randomTopicName();
 
   @Test
   public void testEncryptedKey() {
@@ -243,7 +244,8 @@ public class ConnectionServiceIT {
     // stage exists
     assert conn.stageExist(stageName);
     // put a file to stage
-    String fileName = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, 1, 123, 456);
+    String fileName =
+        FileNameTestUtils.fileName(TEST_CONNECTOR_NAME, tableName, "topic", 1, 123, 456);
     conn.put(stageName, fileName, "test");
     // list stage with prefix
     List<String> files = conn.listStage(stageName, TEST_CONNECTOR_NAME);
@@ -332,17 +334,23 @@ public class ConnectionServiceIT {
     // stage exists
     assert conn.stageExist(stageName);
     // put two files to stage
-    String fileName1 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, 1, 1, 3);
+    String fileName1 =
+        FileNameTestUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 1, 3);
     conn.put(stageName, fileName1, "test");
-    String fileName2 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, 1, 4, 6);
+    String fileName2 =
+        FileNameTestUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 4, 6);
     conn.put(stageName, fileName2, "test");
-    String fileName3 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, 1, 14, 16);
+    String fileName3 =
+        FileNameTestUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 14, 16);
     conn.put(stageName, fileName3, "test");
-    String fileName4 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, 1, 24, 26);
+    String fileName4 =
+        FileNameTestUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 24, 26);
     conn.put(stageName, fileName4, "test");
-    String fileName5 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, 1, 34, 36);
+    String fileName5 =
+        FileNameTestUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 34, 36);
     conn.put(stageName, fileName5, "test");
-    String fileName6 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, 1, 44, 46);
+    String fileName6 =
+        FileNameTestUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 44, 46);
     conn.put(stageName, fileName6, "test");
     // list stage with prefix
     List<String> files = conn.listStage(stageName, TEST_CONNECTOR_NAME);

--- a/src/test/java/com/snowflake/kafka/connector/internal/FileNameTestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/FileNameTestUtils.java
@@ -1,0 +1,64 @@
+package com.snowflake.kafka.connector.internal;
+
+import static com.snowflake.kafka.connector.internal.FileNameUtils.filePrefix;
+
+public class FileNameTestUtils {
+  private FileNameTestUtils() {}
+
+  // Used for testing only
+  static String fileName(
+      String appName, String table, String topic, int partition, long start, long end, long time) {
+    return filePrefix(appName, table, topic, partition)
+        + start
+        + "_"
+        + end
+        + "_"
+        + time
+        + ".json.gz";
+  }
+
+  /**
+   * generate file name File Name Format: app/table/partition/start_end_timeStamp.fileFormat.gz
+   * Note: all file names should using the this format
+   *
+   * @param appName connector name
+   * @param table table name
+   * @param topic name
+   * @param partition partition number
+   * @param start start offset
+   * @param end end offset
+   * @return file name
+   */
+  public static String fileName(
+      String appName, String table, String topic, int partition, long start, long end) {
+    String prefix = filePrefix(appName, table, topic, partition);
+    return FileNameUtils.fileName(prefix, start, end);
+  }
+
+  /**
+   * generate file name for broken data
+   *
+   * @param appName app name
+   * @param table table name
+   * @param partition partition id
+   * @param offset record offset
+   * @param isKey is the broken record a key or a value
+   * @return file name
+   */
+  static String brokenRecordFileName(
+      String appName, String table, String topic, int partition, long offset, boolean isKey) {
+    return FileNameUtils.brokenRecordFileName(
+        filePrefix(appName, table, topic, partition), offset, isKey);
+  }
+
+  /**
+   * check whether the given file is expired
+   *
+   * @param fileName file name
+   * @return true if expired, otherwise false
+   */
+  static boolean isFileExpired(String fileName) {
+    return System.currentTimeMillis() - FileNameUtils.fileNameToTimeIngested(fileName)
+        > InternalUtils.MAX_RECOVERY_TIME;
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/FileNameUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/FileNameUtilsTest.java
@@ -1,5 +1,8 @@
 package com.snowflake.kafka.connector.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Test;
 
 public class FileNameUtilsTest {
@@ -8,50 +11,43 @@ public class FileNameUtilsTest {
     int partition = 123;
     long startOffset = 456L;
     long endOffset = 789L;
-    String topic = "test_topic";
+    String tableName = "test_table";
     long time1 = System.currentTimeMillis();
     Thread.sleep(5); // error in maven without sleep
     String fileName =
-        FileNameUtils.fileName(
-            TestUtils.TEST_CONNECTOR_NAME, topic, partition, startOffset, endOffset);
+        FileNameTestUtils.fileName(
+            TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, endOffset);
     Thread.sleep(5);
     long time2 = System.currentTimeMillis();
 
-    assert !FileNameUtils.verifyFileName("asdasdasdasdsa.json.gz");
-    assert FileNameUtils.verifyFileName(fileName);
-    assert FileNameUtils.fileNameToStartOffset(fileName) == startOffset;
-    assert FileNameUtils.fileNameToEndOffset(fileName) == endOffset;
-    assert FileNameUtils.fileNameToPartition(fileName) == partition;
+    assertThat(FileNameUtils.verifyFileName("asdasdasdasdsa.json.gz")).isFalse();
+    assertThat(FileNameUtils.verifyFileName(fileName)).isTrue();
+    assertThat(FileNameUtils.fileNameToStartOffset(fileName)).isEqualTo(startOffset);
+    assertThat(FileNameUtils.fileNameToEndOffset(fileName)).isEqualTo(endOffset);
+    assertThat(FileNameUtils.fileNameToPartition(fileName)).isEqualTo(partition);
 
     long createTime = FileNameUtils.fileNameToTimeIngested(fileName);
-    assert (createTime > time1) && (createTime < time2);
+    assertThat((createTime > time1) && (createTime < time2)).isTrue();
 
-    assert FileNameUtils.removePrefixAndGZFromFileName("A/B/C/abc.tar.gz").equals("abc.tar");
-    assert FileNameUtils.removePrefixAndGZFromFileName("A/B/C/abc.json").equals("abc.json");
-    assert FileNameUtils.getPrefixFromFileName("A/B/C/abc.tar.gz").equals("A/B/C");
-    assert FileNameUtils.getPrefixFromFileName("A/B/C/abc.json").equals("A/B/C");
-    assert FileNameUtils.getPrefixFromFileName("abc.json") == null;
-    assert FileNameUtils.getPrefixFromFileName("abc.json.gz") == null;
-    try {
-      FileNameUtils.getPrefixFromFileName("A/B/C/");
-      assert false;
-    } catch (Exception e) {
-    }
-    try {
-      FileNameUtils.getPrefixFromFileName("");
-      assert false;
-    } catch (Exception e) {
-    }
+    assertThat(FileNameUtils.removePrefixAndGZFromFileName("A/B/C/abc.tar.gz"))
+        .isEqualTo("abc.tar");
+    assertThat(FileNameUtils.removePrefixAndGZFromFileName("A/B/C/abc.json")).isEqualTo("abc.json");
+    assertThat(FileNameUtils.getPrefixFromFileName("A/B/C/abc.tar.gz")).isEqualTo("A/B/C");
+    assertThat(FileNameUtils.getPrefixFromFileName("A/B/C/abc.json")).isEqualTo("A/B/C");
+    assertThat(FileNameUtils.getPrefixFromFileName("abc.json")).isNull();
+    assertThat(FileNameUtils.getPrefixFromFileName("abc.json.gz")).isNull();
+    assertThatThrownBy(() -> FileNameUtils.getPrefixFromFileName("A/B/C/"));
+    assertThatThrownBy(() -> FileNameUtils.getPrefixFromFileName(""));
 
     String brokenFileName =
-        FileNameUtils.brokenRecordFileName(
-            TestUtils.TEST_CONNECTOR_NAME, topic, partition, startOffset, true);
-    assert TestUtils.verifyBrokenRecordName(brokenFileName);
+        FileNameTestUtils.brokenRecordFileName(
+            TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, true);
+    assertThat(TestUtils.verifyBrokenRecordName(brokenFileName)).isTrue();
 
     brokenFileName =
-        FileNameUtils.brokenRecordFileName(
-            TestUtils.TEST_CONNECTOR_NAME, topic, partition, startOffset, false);
-    assert TestUtils.verifyBrokenRecordName(brokenFileName);
+        FileNameTestUtils.brokenRecordFileName(
+            TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, false);
+    assertThat(TestUtils.verifyBrokenRecordName(brokenFileName)).isTrue();
   }
 
   @Test
@@ -67,8 +63,95 @@ public class FileNameUtilsTest {
             + (time - InternalUtils.MAX_RECOVERY_TIME + 3600 * 1000)
             + ".json.gz";
 
-    assert FileNameUtils.isFileExpired(expiredFile);
+    assertThat(FileNameTestUtils.isFileExpired(expiredFile)).isTrue();
+    assertThat(FileNameTestUtils.isFileExpired(unexpiredFile)).isFalse();
+  }
 
-    assert !FileNameUtils.isFileExpired(unexpiredFile);
+  @Test
+  public void testFileNameWillEncodeTopicNameToCreateUniquePrefix() {
+    int partition = 123;
+    long startOffset = 456L;
+    long endOffset = 789L;
+    String tableName = "test_table";
+    String topicName = "test_topic";
+    long now = System.currentTimeMillis();
+    String fileName =
+        FileNameTestUtils.fileName(
+            TestUtils.TEST_CONNECTOR_NAME, tableName, topicName, partition, startOffset, endOffset);
+
+    assertThat(fileName).isNotNull();
+    assertThat(FileNameUtils.verifyFileName(fileName)).isTrue();
+    assertThat(FileNameUtils.fileNameToPartition(fileName)).isEqualTo(partition);
+    assertThat(FileNameUtils.fileNameToStartOffset(fileName)).isEqualTo(startOffset);
+    assertThat(FileNameUtils.fileNameToEndOffset(fileName)).isEqualTo(endOffset);
+    assertThat(FileNameUtils.fileNameToTimeIngested(fileName))
+        .isGreaterThanOrEqualTo(now - 5000L)
+        .isLessThanOrEqualTo(now + 5000L);
+
+    String prefix = FileNameUtils.getPrefixFromFileName(fileName);
+    // without bit shifting - the expression would match \d\d\d expression, but since we are left
+    // shifting by 16 bits left, it is going to be a larger number
+    assertThat(prefix).matches("^TEST_CONNECTOR/test_table/\\d\\d\\d\\d\\d\\d\\d\\d\\d.*");
+  }
+
+  @Test
+  public void testFileNameWillEncodeTopicNameToCreateUniquePrefixesAndNamesWontCollide() {
+    int partition = 123;
+    long startOffset = 456L;
+    long endOffset = 789L;
+    String tableName = "test_table";
+    String topicName1 = "test_topic1";
+    String topicName2 = "test_topic2";
+    String fileName1 =
+        FileNameTestUtils.fileName(
+            TestUtils.TEST_CONNECTOR_NAME,
+            tableName,
+            topicName1,
+            partition,
+            startOffset,
+            endOffset);
+    String fileName2 =
+        FileNameTestUtils.fileName(
+            TestUtils.TEST_CONNECTOR_NAME,
+            tableName,
+            topicName2,
+            partition,
+            startOffset,
+            endOffset);
+    String fileName3 =
+        FileNameTestUtils.fileName(
+            TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, endOffset);
+    String fileName4 =
+        FileNameTestUtils.fileName(
+            TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, endOffset);
+
+    String prefix1 = FileNameUtils.getPrefixFromFileName(fileName1);
+    String prefix2 = FileNameUtils.getPrefixFromFileName(fileName2);
+    String prefix3 = FileNameUtils.getPrefixFromFileName(fileName3);
+    String prefix4 = FileNameUtils.getPrefixFromFileName(fileName4);
+
+    // prefixes with topic name included won't match
+    assertThat(prefix1).isNotEqualTo(prefix2);
+    // but prefixes without topic name would match
+    assertThat(prefix3).isEqualTo(prefix4);
+  }
+
+  @Test
+  public void testFileNameWontSupportMoreThan32767Partitions() {
+    int partition = 0x8000;
+    long startOffset = 456L;
+    long endOffset = 789L;
+    String tableName = "test_table";
+    String topicName = "test_topic";
+    assertThatThrownBy(
+            () ->
+                FileNameTestUtils.fileName(
+                    TestUtils.TEST_CONNECTOR_NAME,
+                    tableName,
+                    topicName,
+                    partition,
+                    startOffset,
+                    endOffset))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/IngestionServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/IngestionServiceIT.java
@@ -36,7 +36,8 @@ public class IngestionServiceIT {
     String file = "{\"aa\":123}";
     // File Name Format: app/table/partition/start_end_timeStamp.fileFormat.gz
     // start offset = 0, end offset = 1
-    String fileName = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, 0, 0, 1);
+    String fileName =
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, "topic", table, 0, 0, 1);
 
     conn.put(stage, fileName, file);
     ingestService.ingestFile(fileName);

--- a/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatusMetricsIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatusMetricsIT.java
@@ -94,7 +94,7 @@ public class SnowflakeTelemetryPipeStatusMetricsIT {
             conn.listStage(
                         stageName,
                         FileNameUtils.filePrefix(
-                            TestUtils.TEST_CONNECTOR_NAME, tableName, partition))
+                            TestUtils.TEST_CONNECTOR_NAME, tableName, null, partition))
                     .size()
                 == 0,
         30,

--- a/src/test/java/com/snowflake/kafka/connector/internal/StageFilesProcessor_FileCategorizerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/StageFilesProcessor_FileCategorizerTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Functions;
 import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -14,11 +16,15 @@ import java.util.stream.IntStream;
 import net.snowflake.client.jdbc.internal.joda.time.DateTime;
 import net.snowflake.client.jdbc.internal.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class StageFilesProcessor_FileCategorizerTest {
   @Test
   void allFilesWillBeCategorizedAsStageFilesWhenNoInitialOffsetIsSupplied() {
     DateTime ts = new DateTime(2000, 1, 10, 12, 0, DateTimeZone.UTC);
+    StageFilesProcessor.FilteringPredicates filters =
+        new StageFilesProcessor.FilteringPredicates(() -> ts.toInstant().getMillis(), "");
     List<String> files =
         IntStream.rangeClosed(0, 9)
             .mapToObj(
@@ -31,7 +37,7 @@ class StageFilesProcessor_FileCategorizerTest {
             .collect(Collectors.toList());
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
 
     assertThat(victim.hasDirtyFiles()).isFalse();
     assertThat(victim.hasStageFiles()).isTrue();
@@ -41,6 +47,8 @@ class StageFilesProcessor_FileCategorizerTest {
   @Test
   void filesOlderThen1MinuteWillBeCategorizedAsMature() {
     DateTime ts = new DateTime(2000, 1, 10, 12, 0, DateTimeZone.UTC);
+    StageFilesProcessor.FilteringPredicates filters =
+        new StageFilesProcessor.FilteringPredicates(() -> ts.toInstant().getMillis(), "");
     List<String> files = new ArrayList<>();
     String matureFile =
         String.format(
@@ -60,10 +68,7 @@ class StageFilesProcessor_FileCategorizerTest {
     files.add(toYoungFile);
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
-
-    StageFilesProcessor.FilteringPredicates filters =
-        new StageFilesProcessor.FilteringPredicates(ts::getMillis, "");
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
 
     assertThat(victim.hasDirtyFiles()).isFalse();
     assertThat(victim.hasStageFiles()).isTrue();
@@ -74,6 +79,8 @@ class StageFilesProcessor_FileCategorizerTest {
   @Test
   void filesYoungerThen1MinuteWillNotBeCategorizedAsLoaded() {
     DateTime ts = new DateTime(2000, 1, 10, 12, 0, DateTimeZone.UTC);
+    StageFilesProcessor.FilteringPredicates filters =
+        new StageFilesProcessor.FilteringPredicates(() -> ts.toInstant().getMillis(), "");
     List<String> files = new ArrayList<>();
     String matureFile =
         String.format(
@@ -93,7 +100,7 @@ class StageFilesProcessor_FileCategorizerTest {
     files.add(toYoungFile);
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
     Map<String, StageFilesProcessor.IngestEntry> statuses =
         files.stream()
             .collect(
@@ -103,9 +110,6 @@ class StageFilesProcessor_FileCategorizerTest {
                         new StageFilesProcessor.IngestEntry(
                             InternalUtils.IngestedFileStatus.LOADED, ts.getMillis())));
     victim.updateFileStatus(statuses);
-
-    StageFilesProcessor.FilteringPredicates filters =
-        new StageFilesProcessor.FilteringPredicates(ts::getMillis, "");
 
     assertThat(victim.hasDirtyFiles()).isFalse();
     assertThat(victim.hasStageFiles()).isTrue();
@@ -117,6 +121,8 @@ class StageFilesProcessor_FileCategorizerTest {
   @Test
   void filesYoungerThen1MinuteWillNotBeCategorizedAsFailed() {
     DateTime ts = new DateTime(2000, 1, 10, 12, 0, DateTimeZone.UTC);
+    StageFilesProcessor.FilteringPredicates filters =
+        new StageFilesProcessor.FilteringPredicates(() -> ts.toInstant().getMillis(), "");
     List<String> files = new ArrayList<>();
     String matureFile =
         String.format(
@@ -136,7 +142,7 @@ class StageFilesProcessor_FileCategorizerTest {
     files.add(toYoungFile);
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
     Map<String, StageFilesProcessor.IngestEntry> statuses =
         files.stream()
             .collect(
@@ -147,9 +153,6 @@ class StageFilesProcessor_FileCategorizerTest {
                             InternalUtils.IngestedFileStatus.FAILED, ts.getMillis())));
     victim.updateFileStatus(statuses);
 
-    StageFilesProcessor.FilteringPredicates filters =
-        new StageFilesProcessor.FilteringPredicates(ts::getMillis, "");
-
     assertThat(victim.hasDirtyFiles()).isFalse();
     assertThat(victim.hasStageFiles()).isTrue();
     assertThat(victim.query(filters.failedFilesPredicate).collect(Collectors.toList())).isEmpty();
@@ -158,10 +161,36 @@ class StageFilesProcessor_FileCategorizerTest {
   }
 
   @Test
-  void allFilesWillBeCategorizedAsDirtyFilesIfOffsetIsSmallerThanLastSubmittedFile() {
+  void allMatureFilesWillBeCategorizedAsDirtyFilesIfOffsetIsSmallerThanLastSubmittedFile() {
     DateTime ts = new DateTime(2000, 1, 10, 12, 0, DateTimeZone.UTC);
+    StageFilesProcessor.FilteringPredicates filters =
+        new StageFilesProcessor.FilteringPredicates(() -> ts.toInstant().getMillis(), "");
     List<String> files =
-        IntStream.rangeClosed(0, 9)
+        IntStream.rangeClosed(1, 10)
+            .mapToObj(
+                i ->
+                    String.format(
+                        "connector/topic/0/%d_%d_%d.json.gz",
+                        i * 100,
+                        ((i + 1) * 100) - 1,
+                        ts.getMillis() - Duration.ofMinutes(i).toMillis()))
+            .collect(Collectors.toList());
+
+    StageFilesProcessor.FileCategorizer victim =
+        StageFilesProcessor.FileCategorizer.build(files, -1, filters);
+
+    assertThat(victim.hasDirtyFiles()).isTrue();
+    assertThat(victim.hasStageFiles()).isFalse();
+    assertThat(victim.query(t -> true).collect(Collectors.toList())).isEmpty();
+  }
+
+  @Test
+  void allFreshFilesWillBeCategorizedAsStageFilesIfTheyHaventMatured() {
+    DateTime ts = new DateTime(2000, 1, 10, 12, 0, DateTimeZone.UTC);
+    StageFilesProcessor.FilteringPredicates filters =
+        new StageFilesProcessor.FilteringPredicates(() -> ts.toInstant().getMillis(), "");
+    List<String> files =
+        IntStream.rangeClosed(1, 10)
             .mapToObj(
                 i ->
                     String.format(
@@ -172,11 +201,11 @@ class StageFilesProcessor_FileCategorizerTest {
             .collect(Collectors.toList());
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, 0);
+        StageFilesProcessor.FileCategorizer.build(files, -1, filters);
 
-    assertThat(victim.hasDirtyFiles()).isTrue();
-    assertThat(victim.hasStageFiles()).isFalse();
-    assertThat(victim.query(t -> true).collect(Collectors.toList())).isEmpty();
+    assertThat(victim.hasDirtyFiles()).isFalse();
+    assertThat(victim.hasStageFiles()).isTrue();
+    assertThat(victim.query(t -> true).collect(Collectors.toList())).hasSize(10).containsAll(files);
   }
 
   @Test
@@ -208,7 +237,7 @@ class StageFilesProcessor_FileCategorizerTest {
                             InternalUtils.IngestedFileStatus.LOADED, ts.getMillis())));
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
     victim.updateFileStatus(statuses);
 
     assertThat(victim.query(filters.loadedFilesPredicate).collect(Collectors.toList()))
@@ -253,7 +282,7 @@ class StageFilesProcessor_FileCategorizerTest {
                             ts.getMillis())));
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
     victim.updateFileStatus(statuses);
 
     assertThat(victim.query(filters.loadedFilesPredicate).collect(Collectors.toList())).isEmpty();
@@ -282,7 +311,7 @@ class StageFilesProcessor_FileCategorizerTest {
             .collect(Collectors.toList());
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
 
     assertThat(victim.query(filters.loadedFilesPredicate).collect(Collectors.toList())).isEmpty();
     assertThat(victim.query(filters.failedFilesPredicate).collect(Collectors.toList()))
@@ -311,7 +340,7 @@ class StageFilesProcessor_FileCategorizerTest {
             .collect(Collectors.toList());
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
 
     assertThat(victim.query(filters.loadedFilesPredicate).collect(Collectors.toList())).isEmpty();
     assertThat(victim.query(filters.failedFilesPredicate).collect(Collectors.toList())).isEmpty();
@@ -366,12 +395,51 @@ class StageFilesProcessor_FileCategorizerTest {
     statuses.put(files.get(0), InternalUtils.IngestedFileStatus.LOADED);
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
     victim.stopTrackingFiles(files);
 
     assertThat(victim.query(filters.loadedFilesPredicate).collect(Collectors.toList())).isEmpty();
     assertThat(victim.query(filters.failedFilesPredicate).collect(Collectors.toList())).isEmpty();
     assertThat(victim.query(filters.staledFilesPredicate).collect(Collectors.toList())).isEmpty();
-    ;
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {Long.MIN_VALUE, Long.MAX_VALUE})
+  void fileTestFor_SNOW_1642799(long offset) {
+    String fileTimestamp = "28 Aug 2024 @ 17:32:40.822 UTC";
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd MMM yyyy '@' HH:mm:ss.SSS z");
+    // Parse the string to a ZonedDateTime object
+    ZonedDateTime fileTs = ZonedDateTime.parse(fileTimestamp, formatter);
+    ArrayList<String> files = new ArrayList<>();
+    files.add(
+        String.format(
+            "lcc_odgzj_2129566559/EDGE_EVENTABLE_ADHOCAVROV1_PROD_PRIVATE/2/576942355_576942400_%d.json.gz",
+            fileTs.toInstant().toEpochMilli()));
+
+    Map<String, StageFilesProcessor.IngestEntry> statuses = new HashMap<>();
+
+    String cleanerExecutionTime = "28 Aug 2024 @ 17:32:58.118 UTC";
+    ZonedDateTime cleanerRunTime = ZonedDateTime.parse(cleanerExecutionTime, formatter);
+
+    StageFilesProcessor.TimeSupplier timeSupplier = () -> cleanerRunTime.toInstant().toEpochMilli();
+    StageFilesProcessor.FilteringPredicates filters =
+        new StageFilesProcessor.FilteringPredicates(timeSupplier, "lcc_odgzj_2129566559");
+    StageFilesProcessor.FileCategorizer victim =
+        StageFilesProcessor.FileCategorizer.build(files, offset, filters);
+
+    String fileUploadTime = "28 Aug 2024 @ 17:32:41.113 UTC";
+    statuses.put(
+        files.get(0),
+        new StageFilesProcessor.IngestEntry(
+            InternalUtils.IngestedFileStatus.NOT_FOUND,
+            ZonedDateTime.parse(fileUploadTime, formatter).toInstant().toEpochMilli()));
+    victim.updateFileStatus(statuses);
+
+    assertThat(victim.query(filters.trackableFilesPredicate).collect(Collectors.toList()))
+        .isNotEmpty();
+    assertThat(victim.query(filters.matureFilePredicate).collect(Collectors.toList())).isEmpty();
+    assertThat(victim.query(filters.loadedFilesPredicate).collect(Collectors.toList())).isEmpty();
+    assertThat(victim.query(filters.staledFilesPredicate).collect(Collectors.toList())).isEmpty();
+    assertThat(victim.hasDirtyFiles()).isFalse();
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -444,6 +444,10 @@ public class TestUtils {
     return randomName("pipe");
   }
 
+  public static String randomTopicName() {
+    return randomName("topic");
+  }
+
   /**
    * retrieve one properties
    *


### PR DESCRIPTION
SNOW-1642799: added exception handler when moving invalid file to table stage; file cleaner will preserve 'dirty' files a bit longer

Cherrypick https://github.com/snowflakedb/snowflake-kafka-connector/pull/931