### PR TITLE
CC-29888 fix: Set correct offset in StageFilesProcessorTest for dirty files

### DIFF
--- a/src/test/java/com/snowflake/kafka/connector/internal/StageFilesProcessorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/StageFilesProcessorTest.java
@@ -400,7 +400,7 @@ class StageFilesProcessorTest {
     String file3 = String.format("connector/topic/0/300_399_%d.json.gz", currentTime.get());
 
     // reset offset before first file
-    register.newOffset(100L);
+    register.newOffset(99L);
     register.registerNewStageFile(file1);
     register.registerNewStageFile(file2);
     register.registerNewStageFile(file3);


### PR DESCRIPTION
The test was setting an initial offset of 100 which equals the start offset of the first test file (100_199). Since files are only marked as dirty when their start offset is strictly greater than current offset ([ref](https://github.com/confluentinc/snowflake-kafka-connector/blob/6c2ce0ef356e23beee4022498867da737fa4ad2d/src/main/java/com/snowflake/kafka/connector/internal/StageFilesProcessor.java#L508)), changed initial offset to 99L to ensure proper testing of the dirty file detection logic.


Also this was fixed by the snowflake team in the upstream as well, but was not backported to 2.2.x . Check:
2.2 - https://github.com/snowflakedb/snowflake-kafka-connector/blob/v2.2.2/src/test/java/com/snowflake/kafka/connector/internal/StageFilesProcessorTest.java

2.3 - https://github.com/snowflakedb/snowflake-kafka-connector/blob/v2.3.0/src/test/java/com/snowflake/kafka/connector/internal/StageFilesProcessorTest.java