### PR TITLE
CC-30278 Clean files from stage only if status loaded

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -127,6 +127,10 @@ public class SnowflakeSinkConnectorConfig {
   public static final boolean SNOWPIPE_FILE_CLEANER_FIX_ENABLED_DEFAULT = false;
   public static final int SNOWPIPE_FILE_CLEANER_THREADS_DEFAULT = 1;
 
+  public static final String SNOWPIPE_CLEAN_FILES_ONLY_IF_STATUS_LOADED =
+          "snowflake.snowpipe.v1Cleaner.cleanFilesOnlyIfStatusLoaded";
+  public static final boolean SNOWPIPE_CLEAN_FILES_ONLY_IF_STATUS_LOADED_DEFAULT = true;
+
   public static final String SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED =
       "snowflake.snowpipe.stageFileNameExtensionEnabled";
   public static final boolean SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED_DEFAULT = true;
@@ -582,6 +586,12 @@ public class SnowflakeSinkConnectorConfig {
             Importance.LOW,
             "Defines number of worker threads to associate with the cleaner task. By default there"
                 + " is one cleaner per topic's partition and they all share one worker thread")
+        .define(
+            SNOWPIPE_CLEAN_FILES_ONLY_IF_STATUS_LOADED,
+            Type.BOOLEAN,
+            SNOWPIPE_CLEAN_FILES_ONLY_IF_STATUS_LOADED_DEFAULT,
+            Importance.LOW,
+            "Whether to clean files only after they are loaded into Snowflake")
         .define(
             SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED,
             ConfigDef.Type.BOOLEAN,

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
@@ -85,6 +85,18 @@ public class SnowflakeSinkServiceFactory {
                           .SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED));
         }
         svc.configureSingleTableLoadFromMultipleTopics(extendedStageFileNameFix);
+
+        boolean cleanFilesOnlyIfStatusLoaded =
+            SnowflakeSinkConnectorConfig.SNOWPIPE_CLEAN_FILES_ONLY_IF_STATUS_LOADED_DEFAULT;
+        if (connectorConfig != null
+            && connectorConfig.containsKey(
+                SnowflakeSinkConnectorConfig.SNOWPIPE_CLEAN_FILES_ONLY_IF_STATUS_LOADED)) {
+          cleanFilesOnlyIfStatusLoaded =
+              Boolean.parseBoolean(
+                  connectorConfig.get(
+                      SnowflakeSinkConnectorConfig.SNOWPIPE_CLEAN_FILES_ONLY_IF_STATUS_LOADED));
+        }
+        svc.configureCleanFilesOnlyIfStatusLoaded(cleanFilesOnlyIfStatusLoaded);
       } else {
         this.service = new SnowflakeSinkServiceV2(conn, connectorConfig);
       }


### PR DESCRIPTION
In Snowflake, we track the status of files based on whether they have been processed by Snowpipe and successfully ingested into the Snowflake table. We've added a new configuration option that, when enabled, cleaner will delete only the files from the stage that have already been loaded into the Snowflake table. This will help us to prevent the data loss issue reported in RCCA-24106.