### PR TITLE
Log the deviation in pipe definition if encountered

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -618,7 +618,7 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
         String expectedPipeDefinition = pipeDefinition(tableName, stageName);
         compatible = definition.equalsIgnoreCase(expectedPipeDefinition);
         if (!compatible) {
-          LOGGER.error("Pipe definition {} is not same as expected definition {}",
+          LOGGER.error("Pipe definition '{}' is not same as expected definition '{}'",
               definition, expectedPipeDefinition);
         }
       }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -615,7 +615,12 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
       } else {
         String definition = result.getString("definition");
         LOGGER.debug("pipe {} definition: {}", pipeName, definition);
-        compatible = definition.equalsIgnoreCase(pipeDefinition(tableName, stageName));
+        String expectedPipeDefinition = pipeDefinition(tableName, stageName);
+        compatible = definition.equalsIgnoreCase(expectedPipeDefinition);
+        if (!compatible) {
+          LOGGER.error("Pipe definition {} is not same as expected definition {}",
+              definition, expectedPipeDefinition);
+        }
       }
 
     } catch (SQLException e) {


### PR DESCRIPTION
Test run -> https://semaphore.ci.confluent.io/branches/eaa316f1-7f70-4787-8ab0-7416b23cb07b