### PR TITLE
CC-34826: APPSEC-5620: Add FilteringDNSResolver configs

### DIFF
--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -497,7 +497,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>2.0.4-1</version>
+            <version>2.0.4-2</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.snowflake</groupId>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -497,7 +497,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>2.0.4-3</version>
+            <version>2.1.5-2</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.snowflake</groupId>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -611,6 +611,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/io.confluent/connect-utils -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>connect-utils</artifactId>
+            <version>0.6.4</version>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -497,7 +497,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>2.0.3-1</version>
+            <version>2.0.4-1</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.snowflake</groupId>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -497,7 +497,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>2.0.4-2</version>
+            <version>2.0.4-3</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.snowflake</groupId>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -497,7 +497,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>2.0.2-1</version>
+            <version>2.0.3-1</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.snowflake</groupId>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -497,7 +497,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>2.1.5-1</version>
+            <version>2.0.2-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.snowflake</groupId>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -497,7 +497,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>2.0.2-SNAPSHOT</version>
+            <version>2.0.2-1</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.snowflake</groupId>

--- a/scripts/process_licenses.py
+++ b/scripts/process_licenses.py
@@ -33,7 +33,7 @@ GO_LICENSE = "The Go license"
 BOUNCY_CASTLE_LICENSE = "Bouncy Castle License"
 
 # The SDK does not need to include licenses of dependencies, which aren't shaded
-IGNORED_DEPENDENCIES = {"net.snowflake:snowflake-jdbc", "org.slf4j:slf4j-api"}
+IGNORED_DEPENDENCIES = {"net.snowflake:snowflake-jdbc", "org.slf4j:slf4j-api", "io.confluent:connect-utils"}
 
 # List of dependencies, which don't ship with a license file.
 # Only add a new record here after verifying that the dependency JAR does not contain a license!

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -77,6 +77,13 @@ public class SnowflakeSinkConnectorConfig {
   static final String OAUTH_CLIENT_SECRET = Utils.SF_OAUTH_CLIENT_SECRET;
   static final String OAUTH_REFRESH_TOKEN = Utils.SF_OAUTH_REFRESH_TOKEN;
 
+  // Connection security
+  public static final String DISALLOW_LOCAL_IPS = "connection.disallow.local.ips";
+  public static final boolean DISALLOW_LOCAL_IPS_DEFAULT = true;
+  public static final String DISALLOW_LOCAL_IPS_DOC = "Disallow local IP addresses after DNS "
+      + "resolution.";
+  public static final String DISALLOW_LOCAL_IPS_DISPLAY = "Disallow local IP addresses";
+
   // For Snowpipe Streaming client
   public static final String SNOWFLAKE_ROLE = Utils.SF_ROLE;
   public static final String ENABLE_SCHEMATIZATION_CONFIG = "snowflake.enable.schematization";
@@ -499,15 +506,15 @@ public class SnowflakeSinkConnectorConfig {
             ConfigDef.Width.NONE,
             SNOWFLAKE_HTTPS_PROXY_USER)
         .define(
-            SNOWFLAKE_HTTPS_PROXY_PASSWORD,
-            Type.PASSWORD,
-            "",
+            DISALLOW_LOCAL_IPS,
+            Type.BOOLEAN,
+            DISALLOW_LOCAL_IPS_DEFAULT,
             Importance.LOW,
-            "HTTPS proxy password for Snowflake connections",
+            DISALLOW_LOCAL_IPS_DOC,
             PROXY_INFO,
             10,
             ConfigDef.Width.NONE,
-            SNOWFLAKE_HTTPS_PROXY_PASSWORD)
+            DISALLOW_LOCAL_IPS_DISPLAY)
         // Connector Config
         .define(
             TOPICS_TABLES_MAP,

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -84,6 +84,30 @@ public class SnowflakeSinkConnectorConfig {
       + "resolution.";
   public static final String DISALLOW_LOCAL_IPS_DISPLAY = "Disallow local IP addresses";
 
+  public static final String DISALLOW_PRIVATE_IPS = "connection.disallow.private.ips";
+  public static final boolean DISALLOW_PRIVATE_IPS_DEFAULT = true;
+  public static final String DISALLOW_PRIVATE_IPS_DOC = "Disallow private IP addresses after DNS "
+      + "resolution.";
+  public static final String DISALLOW_PRIVATE_IPS_DISPLAY = "Disallow private IP addresses";
+
+  public static final String DISALLOW_CLASS_E_IPS = "connection.disallow.class.e.ips";
+  public static final boolean DISALLOW_CLASS_E_IPS_DEFAULT = true;
+  public static final String DISALLOW_CLASS_E_IPS_DOC = "Disallow Class E IP addresses after DNS "
+      + "resolution.";
+  public static final String DISALLOW_CLASS_E_IPS_DISPLAY = "Disallow Class E IP addresses";
+
+  public static final String DISALLOW_CIDR_RANGES = "connection.disallow.cidr.ranges";
+  public static final String DISALLOW_CIDR_RANGES_DEFAULT = "";
+  public static final String DISALLOW_CIDR_RANGES_DOC = "Disallow IP addresses from the "
+      + "configured CIDR ranges after DNS resolution.";
+  public static final String DISALLOW_CIDR_RANGES_DISPLAY = "Disallow CIDR ranges";
+
+  public static final String ALLOW_CIDR_RANGES = "connection.allow.cidr.ranges";
+  public static final String ALLOW_CIDR_RANGES_DEFAULT = "";
+  public static final String ALLOW_CIDR_RANGES_DOC = "Allow IP addresses from the "
+      + "configured CIDR ranges after DNS resolution.";
+  public static final String ALLOW_CIDR_RANGES_DISPLAY = "Allow CIDR ranges";
+
   // For Snowpipe Streaming client
   public static final String SNOWFLAKE_ROLE = Utils.SF_ROLE;
   public static final String ENABLE_SCHEMATIZATION_CONFIG = "snowflake.enable.schematization";
@@ -515,6 +539,46 @@ public class SnowflakeSinkConnectorConfig {
             10,
             ConfigDef.Width.NONE,
             DISALLOW_LOCAL_IPS_DISPLAY)
+        .define(
+            DISALLOW_PRIVATE_IPS,
+            Type.BOOLEAN,
+            DISALLOW_PRIVATE_IPS_DEFAULT,
+            Importance.LOW,
+            DISALLOW_PRIVATE_IPS_DOC,
+            PROXY_INFO,
+            11,
+            ConfigDef.Width.NONE,
+            DISALLOW_PRIVATE_IPS_DISPLAY)
+        .define(
+            DISALLOW_CLASS_E_IPS,
+            Type.BOOLEAN,
+            DISALLOW_CLASS_E_IPS_DEFAULT,
+            Importance.LOW,
+            DISALLOW_CLASS_E_IPS_DOC,
+            PROXY_INFO,
+            12,
+            ConfigDef.Width.NONE,
+            DISALLOW_CLASS_E_IPS_DISPLAY)
+        .define(
+            DISALLOW_CIDR_RANGES,
+            Type.STRING,
+            DISALLOW_CIDR_RANGES_DEFAULT,
+            Importance.LOW,
+            DISALLOW_CIDR_RANGES_DOC,
+            PROXY_INFO,
+            13,
+            ConfigDef.Width.NONE,
+            DISALLOW_CIDR_RANGES_DISPLAY)
+        .define(
+            ALLOW_CIDR_RANGES,
+            Type.STRING,
+            ALLOW_CIDR_RANGES_DEFAULT,
+            Importance.LOW,
+            ALLOW_CIDR_RANGES_DOC,
+            PROXY_INFO,
+            14,
+            ConfigDef.Width.NONE,
+            ALLOW_CIDR_RANGES_DISPLAY)
         // Connector Config
         .define(
             TOPICS_TABLES_MAP,

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -530,13 +530,23 @@ public class SnowflakeSinkConnectorConfig {
             ConfigDef.Width.NONE,
             SNOWFLAKE_HTTPS_PROXY_USER)
         .define(
+            SNOWFLAKE_HTTPS_PROXY_PASSWORD,
+            Type.PASSWORD,
+            "",
+            Importance.LOW,
+            "HTTPS proxy password for Snowflake connections",
+            PROXY_INFO,
+            10,
+            ConfigDef.Width.NONE,
+            SNOWFLAKE_HTTPS_PROXY_PASSWORD)
+        .define(
             DISALLOW_LOCAL_IPS,
             Type.BOOLEAN,
             DISALLOW_LOCAL_IPS_DEFAULT,
             Importance.LOW,
             DISALLOW_LOCAL_IPS_DOC,
             PROXY_INFO,
-            10,
+            11,
             ConfigDef.Width.NONE,
             DISALLOW_LOCAL_IPS_DISPLAY)
         .define(
@@ -546,7 +556,7 @@ public class SnowflakeSinkConnectorConfig {
             Importance.LOW,
             DISALLOW_PRIVATE_IPS_DOC,
             PROXY_INFO,
-            11,
+            12,
             ConfigDef.Width.NONE,
             DISALLOW_PRIVATE_IPS_DISPLAY)
         .define(
@@ -556,7 +566,7 @@ public class SnowflakeSinkConnectorConfig {
             Importance.LOW,
             DISALLOW_CLASS_E_IPS_DOC,
             PROXY_INFO,
-            12,
+            13,
             ConfigDef.Width.NONE,
             DISALLOW_CLASS_E_IPS_DISPLAY)
         .define(
@@ -566,7 +576,7 @@ public class SnowflakeSinkConnectorConfig {
             Importance.LOW,
             DISALLOW_CIDR_RANGES_DOC,
             PROXY_INFO,
-            13,
+            14,
             ConfigDef.Width.NONE,
             DISALLOW_CIDR_RANGES_DISPLAY)
         .define(
@@ -576,7 +586,7 @@ public class SnowflakeSinkConnectorConfig {
             Importance.LOW,
             ALLOW_CIDR_RANGES_DOC,
             PROXY_INFO,
-            14,
+            15,
             ConfigDef.Width.NONE,
             ALLOW_CIDR_RANGES_DISPLAY)
         // Connector Config

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -349,10 +349,10 @@ public class InternalUtils {
         proxyProperties.put(SFSessionProperty.PROXY_PASSWORD.getPropertyKey(), password);
       }
 
-      // Add disallow local IPs config if present
-      String disallowLocalIps = conf.get(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS);
-      if (disallowLocalIps != null) {
-        proxyProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS, disallowLocalIps);
+      if (conf.containsKey(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS)) {
+        proxyProperties.put(
+                SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS,
+                conf.get(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS));
       }
 
       if (conf.containsKey(SnowflakeSinkConnectorConfig.DISALLOW_PRIVATE_IPS)) {
@@ -378,11 +378,6 @@ public class InternalUtils {
       }
     }
 
-    if (conf.containsKey(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS)) {
-      proxyProperties.put(
-          SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS,
-          conf.get(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS));
-    }
 
     return proxyProperties;
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -380,7 +380,7 @@ public class InternalUtils {
 
     if (conf.containsKey(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS)) {
       proxyProperties.put(
-          "connection.disallow.local.ips",
+          SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS,
           conf.get(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS));
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -354,7 +354,36 @@ public class InternalUtils {
       if (disallowLocalIps != null) {
         proxyProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS, disallowLocalIps);
       }
+
+      if (conf.containsKey(SnowflakeSinkConnectorConfig.DISALLOW_PRIVATE_IPS)) {
+        proxyProperties.put(
+            "connection.disallow.private.ips",
+            conf.get(SnowflakeSinkConnectorConfig.DISALLOW_PRIVATE_IPS));
+      }
+
+      if (conf.containsKey(SnowflakeSinkConnectorConfig.DISALLOW_CLASS_E_IPS)) {
+        proxyProperties.put(
+            SnowflakeSinkConnectorConfig.DISALLOW_CLASS_E_IPS,
+            conf.get(SnowflakeSinkConnectorConfig.DISALLOW_CLASS_E_IPS));
+      }
+      if (conf.containsKey(SnowflakeSinkConnectorConfig.DISALLOW_CIDR_RANGES)) {
+        proxyProperties.put(
+            SnowflakeSinkConnectorConfig.DISALLOW_CIDR_RANGES,
+            conf.get(SnowflakeSinkConnectorConfig.DISALLOW_CIDR_RANGES));
+      }
+      if (conf.containsKey(SnowflakeSinkConnectorConfig.ALLOW_CIDR_RANGES)) {
+        proxyProperties.put(
+            SnowflakeSinkConnectorConfig.ALLOW_CIDR_RANGES,
+            conf.get(SnowflakeSinkConnectorConfig.ALLOW_CIDR_RANGES));
+      }
     }
+
+    if (conf.containsKey(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS)) {
+      proxyProperties.put(
+          "connection.disallow.local.ips",
+          conf.get(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS));
+    }
+
     return proxyProperties;
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -348,6 +348,12 @@ public class InternalUtils {
         proxyProperties.put(SFSessionProperty.PROXY_USER.getPropertyKey(), username);
         proxyProperties.put(SFSessionProperty.PROXY_PASSWORD.getPropertyKey(), password);
       }
+
+      // Add disallow local IPs config if present
+      String disallowLocalIps = conf.get(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS);
+      if (disallowLocalIps != null) {
+        proxyProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS, disallowLocalIps);
+      }
     }
     return proxyProperties;
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -205,6 +205,14 @@ public class StreamingUtils {
           return value;
         });
 
+    // Add disallow local IPs config if present
+    connectorConfig.computeIfPresent(
+        SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS,
+        (key, value) -> {
+          streamingProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS, value);
+          return value;
+        });
+
     return streamingProperties;
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -213,6 +213,33 @@ public class StreamingUtils {
           return value;
         });
 
+    // Add disallow private IPs config if present
+    connectorConfig.computeIfPresent(
+        SnowflakeSinkConnectorConfig.DISALLOW_PRIVATE_IPS,
+        (key, value) -> {
+          streamingProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_PRIVATE_IPS, value);
+          return value;
+        });
+
+    connectorConfig.computeIfPresent(
+        SnowflakeSinkConnectorConfig.DISALLOW_CLASS_E_IPS,
+        (key, value) -> {
+          streamingProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_CLASS_E_IPS, value);
+          return value;
+        });
+    connectorConfig.computeIfPresent(
+        SnowflakeSinkConnectorConfig.DISALLOW_CIDR_RANGES,
+        (key, value) -> {
+          streamingProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_CIDR_RANGES, value);
+          return value;
+        });
+    connectorConfig.computeIfPresent(
+        SnowflakeSinkConnectorConfig.ALLOW_CIDR_RANGES,
+        (key, value) -> {
+          streamingProperties.put(SnowflakeSinkConnectorConfig.ALLOW_CIDR_RANGES, value);
+          return value;
+        });
+
     return streamingProperties;
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -307,7 +307,14 @@ public class TestUtils {
 
   /* Get configuration map from profile path. Used against prod deployment of Snowflake */
   public static Map<String, String> getConf() {
-    return getConfFromFileName(PROFILE_PATH);
+    Map<String, String> configuration = getConfFromFileName(PROFILE_PATH);
+    
+    // Disable connection restrictions for tests to allow localhost connections
+    configuration.put("connection.disallow.local.ips", "false");
+    configuration.put("connection.disallow.private.ips", "false");
+    configuration.put("connection.disallow.class.e.ips", "false");
+    
+    return configuration;
   }
 
   /* Get configuration map from profile path. Used against prod deployment of Snowflake */
@@ -320,6 +327,11 @@ public class TestUtils {
     configuration.put(
         SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
         IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    
+    // Disable connection restrictions for tests to allow localhost connections
+    configuration.put("connection.disallow.local.ips", "false");
+    configuration.put("connection.disallow.private.ips", "false");
+    configuration.put("connection.disallow.class.e.ips", "false");
 
     return configuration;
   }
@@ -349,6 +361,11 @@ public class TestUtils {
     config.remove(Utils.SF_PRIVATE_KEY);
     config.put(Utils.SF_PRIVATE_KEY, getEncryptedPrivateKey());
     config.put(Utils.PRIVATE_KEY_PASSPHRASE, getPrivateKeyPassphrase());
+    
+    // Disable connection restrictions for tests to allow localhost connections
+    config.put("connection.disallow.local.ips", "false");
+    config.put("connection.disallow.private.ips", "false");
+    config.put("connection.disallow.class.e.ips", "false");
 
     return config;
   }


### PR DESCRIPTION
Appsec review requirement : https://confluentinc.atlassian.net/browse/APPSEC-5620

Reference - confluentinc/connect-utils@ec3f8cb/src/main/java/io/confluent/connect/utils/network/FilteringDnsResolver.java#L37

Connector ref - confluentinc/kafka-connect-http-v2@3a24159/src/main/java/io/confluent/connect/http/common/transport/HttpClientFactory.java#L82-L99