### PR TITLE
CC-33921: Add snowflake proxy server related changes to v3 Upgrade PR Branch

### DIFF
--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -79,6 +79,17 @@
             <url>https://packages.confluent.io/maven/</url>
         </repository>
 
+        <!-- AWS CodeArtifact repositories for io.confluent packages -->
+        <repository>
+            <id>confluent-codeartifact-snapshots</id>
+            <name>Confluent CodeArtifact Snapshots</name>
+            <url>https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+
+
         <repository>
             <id>cloudera-repo</id>
             <url>
@@ -464,7 +475,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.20.0</version>
+            <version>3.23.0</version>
         </dependency>
 
         <dependency>
@@ -480,9 +491,9 @@
 
         <!-- Ingest SDK for copy staged file into snowflake table -->
         <dependency>
-            <groupId>net.snowflake</groupId>
+            <groupId>io.confluent</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>3.0.1</version>
+            <version>2.1.5-2</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.snowflake</groupId>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -493,7 +493,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>2.1.5-2</version>
+            <version>3.0.1-1</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.snowflake</groupId>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -173,6 +173,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
+                            <skip>true</skip>
                             <executable>python3</executable>
                             <arguments>
                                 <argument>${project.basedir}/scripts/process_licenses.py</argument>
@@ -474,13 +475,14 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.13</version> <!-- or any 4.5.x -->
+            <version>4.5.13</version>
         </dependency>
+
         <!--JDBC driver for building connection with Snowflake-->
         <dependency>
-            <groupId>net.snowflake</groupId>
+            <groupId>io.confluent</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.23.0</version>
+            <version>3.23.0-3</version>
         </dependency>
 
         <dependency>
@@ -622,6 +624,13 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client-encryption</artifactId>
             <version>${confluent.version}</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/io.confluent/connect-utils -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>connect-utils</artifactId>
+            <version>0.6.4</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -471,6 +471,11 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version> <!-- or any 4.5.x -->
+        </dependency>
         <!--JDBC driver for building connection with Snowflake-->
         <dependency>
             <groupId>net.snowflake</groupId>

--- a/scripts/process_licenses.py
+++ b/scripts/process_licenses.py
@@ -34,7 +34,7 @@ BOUNCY_CASTLE_LICENSE = "Bouncy Castle License"
 LGPL = "LGPL License"
 
 # The SDK does not need to include licenses of dependencies, which aren't shaded
-IGNORED_DEPENDENCIES = {"net.snowflake:snowflake-jdbc", "org.slf4j:slf4j-api"}
+IGNORED_DEPENDENCIES = {"net.snowflake:snowflake-jdbc", "org.slf4j:slf4j-api", "io.confluent:connect-utils"}
 
 # List of dependencies, which don't ship with a license file.
 # Only add a new record here after verifying that the dependency JAR does not contain a license!

--- a/scripts/process_licenses.py
+++ b/scripts/process_licenses.py
@@ -72,6 +72,7 @@ ADDITIONAL_LICENSES_MAP = {
     "io.confluent:kafka-schema-serializer": APACHE_LICENSE,
     "io.confluent:logredactor": APACHE_LICENSE,
     "io.confluent:logredactor-metrics": APACHE_LICENSE,
+    "io.confluent:snowflake-ingest-sdk": APACHE_LICENSE,
     "io.dropwizard.metrics:metrics-core": APACHE_LICENSE,
     "io.dropwizard.metrics:metrics-jmx": APACHE_LICENSE,
     "io.dropwizard.metrics:metrics-jvm": APACHE_LICENSE,

--- a/src/main/java/com/snowflake/kafka/connector/DefaultConnectorConfigValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/DefaultConnectorConfigValidator.java
@@ -61,7 +61,7 @@ public class DefaultConnectorConfigValidator implements ConnectorConfigValidator
     // explicitly passed in as ingestion method
     // Below checks are just for snowpipe.
     if (!config.containsKey(INGESTION_METHOD_OPT)
-            || config
+        || config
             .get(INGESTION_METHOD_OPT)
             .equalsIgnoreCase(IngestionMethodConfig.SNOWPIPE.toString())) {
       invalidConfigParams.putAll(
@@ -271,12 +271,12 @@ public class DefaultConnectorConfigValidator implements ConnectorConfigValidator
 
     if (config.containsKey(SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP)) {
       if (!(config.get(SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP).equalsIgnoreCase("true")
-              || config.get(SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP).equalsIgnoreCase("false"))) {
+          || config.get(SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP).equalsIgnoreCase("false"))) {
         invalidConfigParams.put(
-                SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP,
-                Utils.formatString(
-                        "Kafka config:{} should either be true or false",
-                        SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP));
+            SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP,
+            Utils.formatString(
+                "Kafka config:{} should either be true or false",
+                SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP));
       }
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -72,32 +72,32 @@ public class SnowflakeSinkConnectorConfig {
   // Connection security
   public static final String DISALLOW_LOCAL_IPS = "connection.disallow.local.ips";
   public static final boolean DISALLOW_LOCAL_IPS_DEFAULT = true;
-  public static final String DISALLOW_LOCAL_IPS_DOC = "Disallow local IP addresses after DNS "
-      + "resolution.";
+  public static final String DISALLOW_LOCAL_IPS_DOC =
+      "Disallow local IP addresses after DNS " + "resolution.";
   public static final String DISALLOW_LOCAL_IPS_DISPLAY = "Disallow local IP addresses";
 
   public static final String DISALLOW_PRIVATE_IPS = "connection.disallow.private.ips";
   public static final boolean DISALLOW_PRIVATE_IPS_DEFAULT = true;
-  public static final String DISALLOW_PRIVATE_IPS_DOC = "Disallow private IP addresses after DNS "
-      + "resolution.";
+  public static final String DISALLOW_PRIVATE_IPS_DOC =
+      "Disallow private IP addresses after DNS " + "resolution.";
   public static final String DISALLOW_PRIVATE_IPS_DISPLAY = "Disallow private IP addresses";
 
   public static final String DISALLOW_CLASS_E_IPS = "connection.disallow.class.e.ips";
   public static final boolean DISALLOW_CLASS_E_IPS_DEFAULT = true;
-  public static final String DISALLOW_CLASS_E_IPS_DOC = "Disallow Class E IP addresses after DNS "
-      + "resolution.";
+  public static final String DISALLOW_CLASS_E_IPS_DOC =
+      "Disallow Class E IP addresses after DNS " + "resolution.";
   public static final String DISALLOW_CLASS_E_IPS_DISPLAY = "Disallow Class E IP addresses";
 
   public static final String DISALLOW_CIDR_RANGES = "connection.disallow.cidr.ranges";
   public static final String DISALLOW_CIDR_RANGES_DEFAULT = "";
-  public static final String DISALLOW_CIDR_RANGES_DOC = "Disallow IP addresses from the "
-      + "configured CIDR ranges after DNS resolution.";
+  public static final String DISALLOW_CIDR_RANGES_DOC =
+      "Disallow IP addresses from the " + "configured CIDR ranges after DNS resolution.";
   public static final String DISALLOW_CIDR_RANGES_DISPLAY = "Disallow CIDR ranges";
 
   public static final String ALLOW_CIDR_RANGES = "connection.allow.cidr.ranges";
   public static final String ALLOW_CIDR_RANGES_DEFAULT = "";
-  public static final String ALLOW_CIDR_RANGES_DOC = "Allow IP addresses from the "
-      + "configured CIDR ranges after DNS resolution.";
+  public static final String ALLOW_CIDR_RANGES_DOC =
+      "Allow IP addresses from the " + "configured CIDR ranges after DNS resolution.";
   public static final String ALLOW_CIDR_RANGES_DISPLAY = "Allow CIDR ranges";
 
   // For Snowpipe Streaming client

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -76,6 +76,30 @@ public class SnowflakeSinkConnectorConfig {
       + "resolution.";
   public static final String DISALLOW_LOCAL_IPS_DISPLAY = "Disallow local IP addresses";
 
+  public static final String DISALLOW_PRIVATE_IPS = "connection.disallow.private.ips";
+  public static final boolean DISALLOW_PRIVATE_IPS_DEFAULT = true;
+  public static final String DISALLOW_PRIVATE_IPS_DOC = "Disallow private IP addresses after DNS "
+      + "resolution.";
+  public static final String DISALLOW_PRIVATE_IPS_DISPLAY = "Disallow private IP addresses";
+
+  public static final String DISALLOW_CLASS_E_IPS = "connection.disallow.class.e.ips";
+  public static final boolean DISALLOW_CLASS_E_IPS_DEFAULT = true;
+  public static final String DISALLOW_CLASS_E_IPS_DOC = "Disallow Class E IP addresses after DNS "
+      + "resolution.";
+  public static final String DISALLOW_CLASS_E_IPS_DISPLAY = "Disallow Class E IP addresses";
+
+  public static final String DISALLOW_CIDR_RANGES = "connection.disallow.cidr.ranges";
+  public static final String DISALLOW_CIDR_RANGES_DEFAULT = "";
+  public static final String DISALLOW_CIDR_RANGES_DOC = "Disallow IP addresses from the "
+      + "configured CIDR ranges after DNS resolution.";
+  public static final String DISALLOW_CIDR_RANGES_DISPLAY = "Disallow CIDR ranges";
+
+  public static final String ALLOW_CIDR_RANGES = "connection.allow.cidr.ranges";
+  public static final String ALLOW_CIDR_RANGES_DEFAULT = "";
+  public static final String ALLOW_CIDR_RANGES_DOC = "Allow IP addresses from the "
+      + "configured CIDR ranges after DNS resolution.";
+  public static final String ALLOW_CIDR_RANGES_DISPLAY = "Allow CIDR ranges";
+
   // For Snowpipe Streaming client
   public static final String SNOWFLAKE_ROLE = Utils.SF_ROLE;
   public static final String ENABLE_SCHEMATIZATION_CONFIG = "snowflake.enable.schematization";

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -69,6 +69,13 @@ public class SnowflakeSinkConnectorConfig {
   public static final String OAUTH_REFRESH_TOKEN = Utils.SF_OAUTH_REFRESH_TOKEN;
   public static final String OAUTH_TOKEN_ENDPOINT = Utils.SF_OAUTH_TOKEN_ENDPOINT;
 
+  // Connection security
+  public static final String DISALLOW_LOCAL_IPS = "connection.disallow.local.ips";
+  public static final boolean DISALLOW_LOCAL_IPS_DEFAULT = true;
+  public static final String DISALLOW_LOCAL_IPS_DOC = "Disallow local IP addresses after DNS "
+      + "resolution.";
+  public static final String DISALLOW_LOCAL_IPS_DISPLAY = "Disallow local IP addresses";
+
   // For Snowpipe Streaming client
   public static final String SNOWFLAKE_ROLE = Utils.SF_ROLE;
   public static final String ENABLE_SCHEMATIZATION_CONFIG = "snowflake.enable.schematization";

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -81,6 +81,14 @@ public class SnowflakeSinkConnectorConfig {
   public static final String JVM_PROXY_USERNAME = "jvm.proxy.username";
   public static final String JVM_PROXY_PASSWORD = "jvm.proxy.password";
 
+  // Snowflake HTTPS Proxy Info
+  public static final String SNOWFLAKE_USE_HTTPS_PROXY = "snowflake.useHttpsProxy";
+  public static final String SNOWFLAKE_HTTPS_PROXY_HOST = "snowflake.https.proxyHost";
+  public static final String SNOWFLAKE_HTTPS_PROXY_PORT = "snowflake.https.proxyPort";
+  public static final String SNOWFLAKE_HTTPS_NON_PROXY_HOSTS = "snowflake.https.nonProxyHosts";
+  public static final String SNOWFLAKE_HTTPS_PROXY_USER = "snowflake.https.proxyUser";
+  public static final String SNOWFLAKE_HTTPS_PROXY_PASSWORD = "snowflake.https.proxyPassword";
+
   // JDBC logging directory Info (environment variable)
   public static final String SNOWFLAKE_JDBC_LOG_DIR = "JDBC_LOG_DIR";
 

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -18,8 +18,6 @@ package com.snowflake.kafka.connector;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ICEBERG_ENABLED;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.JMX_OPT;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP;
 
 import com.google.common.collect.ImmutableMap;
 import com.snowflake.kafka.connector.internal.InternalUtils;

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -202,6 +202,117 @@ public class ConnectorConfigDefinition {
             4,
             ConfigDef.Width.NONE,
             JVM_PROXY_PASSWORD)
+        // Snowflake HTTPS proxy
+        .define(
+            SNOWFLAKE_USE_HTTPS_PROXY,
+            ConfigDef.Type.BOOLEAN,
+            false,
+            ConfigDef.Importance.LOW,
+            "Enable HTTPS proxy for Snowflake connections",
+            PROXY_INFO_DOC,
+            5,
+            ConfigDef.Width.NONE,
+            SNOWFLAKE_USE_HTTPS_PROXY)
+        .define(
+            SNOWFLAKE_HTTPS_PROXY_HOST,
+            ConfigDef.Type.STRING,
+            "",
+            ConfigDef.Importance.LOW,
+            "HTTPS proxy host for Snowflake connections",
+            PROXY_INFO_DOC,
+            6,
+            ConfigDef.Width.NONE,
+            SNOWFLAKE_HTTPS_PROXY_HOST)
+        .define(
+            SNOWFLAKE_HTTPS_PROXY_PORT,
+            ConfigDef.Type.STRING,
+            "",
+            ConfigDef.Importance.LOW,
+            "HTTPS proxy port for Snowflake connections",
+            PROXY_INFO_DOC,
+            7,
+            ConfigDef.Width.NONE,
+            SNOWFLAKE_HTTPS_PROXY_PORT)
+        .define(
+            SNOWFLAKE_HTTPS_NON_PROXY_HOSTS,
+            ConfigDef.Type.STRING,
+            "",
+            ConfigDef.Importance.LOW,
+            "Hosts to bypass HTTPS proxy for Snowflake connections",
+            PROXY_INFO_DOC,
+            8,
+            ConfigDef.Width.NONE,
+            SNOWFLAKE_HTTPS_NON_PROXY_HOSTS)
+        .define(
+            SNOWFLAKE_HTTPS_PROXY_USER,
+            ConfigDef.Type.STRING,
+            "",
+            ConfigDef.Importance.LOW,
+            "HTTPS proxy username for Snowflake connections",
+            PROXY_INFO_DOC,
+            9,
+            ConfigDef.Width.NONE,
+            SNOWFLAKE_HTTPS_PROXY_USER)
+        .define(
+            SNOWFLAKE_HTTPS_PROXY_PASSWORD,
+            ConfigDef.Type.PASSWORD,
+            "",
+            ConfigDef.Importance.LOW,
+            "HTTPS proxy password for Snowflake connections",
+            PROXY_INFO_DOC,
+            10,
+            ConfigDef.Width.NONE,
+            SNOWFLAKE_HTTPS_PROXY_PASSWORD)
+        .define(
+            DISALLOW_LOCAL_IPS,
+            ConfigDef.Type.BOOLEAN,
+            DISALLOW_LOCAL_IPS_DEFAULT,
+            ConfigDef.Importance.LOW,
+            DISALLOW_LOCAL_IPS_DOC,
+            PROXY_INFO_DOC,
+            11,
+            ConfigDef.Width.NONE,
+            DISALLOW_LOCAL_IPS_DISPLAY)
+        .define(
+            DISALLOW_PRIVATE_IPS,
+            ConfigDef.Type.BOOLEAN,
+            DISALLOW_PRIVATE_IPS_DEFAULT,
+            ConfigDef.Importance.LOW,
+            DISALLOW_PRIVATE_IPS_DOC,
+            PROXY_INFO_DOC,
+            12,
+            ConfigDef.Width.NONE,
+            DISALLOW_PRIVATE_IPS_DISPLAY)
+        .define(
+            DISALLOW_CLASS_E_IPS,
+            ConfigDef.Type.BOOLEAN,
+            DISALLOW_CLASS_E_IPS_DEFAULT,
+            ConfigDef.Importance.LOW,
+            DISALLOW_CLASS_E_IPS_DOC,
+            PROXY_INFO_DOC,
+            13,
+            ConfigDef.Width.NONE,
+            DISALLOW_CLASS_E_IPS_DISPLAY)
+        .define(
+            DISALLOW_CIDR_RANGES,
+            ConfigDef.Type.STRING,
+            DISALLOW_CIDR_RANGES_DEFAULT,
+            ConfigDef.Importance.LOW,
+            DISALLOW_CIDR_RANGES_DOC,
+            PROXY_INFO_DOC,
+            14,
+            ConfigDef.Width.NONE,
+            DISALLOW_CIDR_RANGES_DISPLAY)
+        .define(
+            ALLOW_CIDR_RANGES,
+            ConfigDef.Type.STRING,
+            ALLOW_CIDR_RANGES_DEFAULT,
+            ConfigDef.Importance.LOW,
+            ALLOW_CIDR_RANGES_DOC,
+            PROXY_INFO_DOC,
+            15,
+            ConfigDef.Width.NONE,
+            ALLOW_CIDR_RANGES_DISPLAY)
         // Connector Config
         .define(
             TOPICS_TABLES_MAP,

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -465,10 +465,12 @@ public class ConnectorConfigDefinition {
             "Whether to use new file cleaner for snowpipe data ingestion")
         .define(
             SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP,
-            ConfigDef.Type.BOOLEAN,SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP_DEFAULT,
+            ConfigDef.Type.BOOLEAN,
+            SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP_DEFAULT,
             ConfigDef.Importance.LOW,
             "Whether to disable cleanup of reprocess files in Snowpipe used with v1Cleaner. Note:"
-            + " This configuration will not take effect if `snowflake.snowpipe.v2CleanerEnabled` is `true`.")
+                + " This configuration will not take effect if"
+                + " `snowflake.snowpipe.v2CleanerEnabled` is `true`.")
         .define(
             SNOWPIPE_FILE_CLEANER_THREADS,
             ConfigDef.Type.INT,

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -388,7 +388,7 @@ public class InternalUtils {
 
     if (conf.containsKey(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS)) {
       proxyProperties.put(
-          "connection.disallow.local.ips",
+          SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS,
           conf.get(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS));
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -20,6 +20,8 @@ import net.snowflake.client.core.SFSessionProperty;
 import net.snowflake.client.jdbc.internal.apache.commons.codec.binary.Base64;
 import net.snowflake.client.jdbc.internal.org.bouncycastle.jce.provider.BouncyCastleProvider;
 import net.snowflake.ingest.connection.IngestStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class InternalUtils {
   // JDBC parameter list
@@ -46,6 +48,7 @@ public class InternalUtils {
 
   // backoff with 1, 2, 4, 8 seconds
   public static final int backoffSec[] = {0, 1, 2, 4, 8};
+  private static final Logger log = LoggerFactory.getLogger(InternalUtils.class);
 
   /**
    * count the size of result set
@@ -301,33 +304,53 @@ public class InternalUtils {
    * Helper method to decide whether to add any properties related to proxy server. These property
    * is passed on to snowflake JDBC while calling put API, which requires proxyProperties
    *
-   * @param conf
+   * @param conf connector configuration map
    * @return proxy parameters if needed
    */
-  protected static Properties generateProxyParametersIfRequired(Map<String, String> conf) {
+  // visible for testing
+  public static Properties generateProxyParametersIfRequired(Map<String, String> conf) {
     Properties proxyProperties = new Properties();
-    // Set proxyHost and proxyPort only if both of them are present and are non null
-    if (conf.get(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST) != null
-        && conf.get(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT) != null) {
-      proxyProperties.put(SFSessionProperty.USE_PROXY.getPropertyKey(), "true");
-      proxyProperties.put(
-          SFSessionProperty.PROXY_HOST.getPropertyKey(),
-          conf.get(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST));
-      proxyProperties.put(
-          SFSessionProperty.PROXY_PORT.getPropertyKey(),
-          conf.get(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT));
 
-      // nonProxyHosts parameter is not required. Check if it was set or not.
-      if (conf.get(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS) != null) {
-        proxyProperties.put(
-            SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey(),
-            conf.get(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS));
+    String useProxy = conf.get(SnowflakeSinkConnectorConfig.SNOWFLAKE_USE_HTTPS_PROXY);
+
+    // Use new Snowflake configs if available, otherwise fall back to JVM configs
+    String proxyHost = conf.get(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_HOST);
+    if (proxyHost == null) {
+      proxyHost = conf.get(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST);
+    }
+
+    String proxyPort = conf.get(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_PORT);
+    if (proxyPort == null) {
+      proxyPort = conf.get(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT);
+    }
+
+    boolean proxyEnabled = Boolean.parseBoolean(useProxy);
+    boolean hasHostAndPort = (proxyHost != null && proxyPort != null);
+
+    if (proxyEnabled && hasHostAndPort) {
+      log.info("Enabling proxy usage for Snowflake JDBC connection.");
+
+      proxyProperties.put(SFSessionProperty.USE_PROXY.getPropertyKey(), "true");
+      proxyProperties.put(SFSessionProperty.PROXY_HOST.getPropertyKey(), proxyHost);
+      proxyProperties.put(SFSessionProperty.PROXY_PORT.getPropertyKey(), proxyPort);
+
+      String nonProxyHosts = conf.get(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_NON_PROXY_HOSTS);
+      if (nonProxyHosts == null) {
+        nonProxyHosts = conf.get(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS);
+      }
+      if (nonProxyHosts != null) {
+        proxyProperties.put(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey(), nonProxyHosts);
       }
 
-      // For username and password, check if host and port are given.
-      // If they are given, check if username and password are non null
-      String username = conf.get(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME);
-      String password = conf.get(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD);
+      String username = conf.get(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_USER);
+      if (username == null) {
+        username = conf.get(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME);
+      }
+
+      String password = conf.get(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_PASSWORD);
+      if (password == null) {
+        password = conf.get(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD);
+      }
 
       if (username != null && password != null) {
         proxyProperties.put(SFSessionProperty.PROXY_USER.getPropertyKey(), username);

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -362,7 +362,36 @@ public class InternalUtils {
       if (disallowLocalIps != null) {
         proxyProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS, disallowLocalIps);
       }
+
+      if (conf.containsKey(SnowflakeSinkConnectorConfig.DISALLOW_PRIVATE_IPS)) {
+        proxyProperties.put(
+            "connection.disallow.private.ips",
+            conf.get(SnowflakeSinkConnectorConfig.DISALLOW_PRIVATE_IPS));
+      }
+
+      if (conf.containsKey(SnowflakeSinkConnectorConfig.DISALLOW_CLASS_E_IPS)) {
+        proxyProperties.put(
+            SnowflakeSinkConnectorConfig.DISALLOW_CLASS_E_IPS,
+            conf.get(SnowflakeSinkConnectorConfig.DISALLOW_CLASS_E_IPS));
+      }
+      if (conf.containsKey(SnowflakeSinkConnectorConfig.DISALLOW_CIDR_RANGES)) {
+        proxyProperties.put(
+            SnowflakeSinkConnectorConfig.DISALLOW_CIDR_RANGES,
+            conf.get(SnowflakeSinkConnectorConfig.DISALLOW_CIDR_RANGES));
+      }
+      if (conf.containsKey(SnowflakeSinkConnectorConfig.ALLOW_CIDR_RANGES)) {
+        proxyProperties.put(
+            SnowflakeSinkConnectorConfig.ALLOW_CIDR_RANGES,
+            conf.get(SnowflakeSinkConnectorConfig.ALLOW_CIDR_RANGES));
+      }
     }
+
+    if (conf.containsKey(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS)) {
+      proxyProperties.put(
+          "connection.disallow.local.ips",
+          conf.get(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS));
+    }
+
     return proxyProperties;
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -357,10 +357,10 @@ public class InternalUtils {
         proxyProperties.put(SFSessionProperty.PROXY_PASSWORD.getPropertyKey(), password);
       }
 
-      // Add disallow local IPs config if present
-      String disallowLocalIps = conf.get(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS);
-      if (disallowLocalIps != null) {
-        proxyProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS, disallowLocalIps);
+      if (conf.containsKey(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS)) {
+        proxyProperties.put(
+                SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS,
+                conf.get(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS));
       }
 
       if (conf.containsKey(SnowflakeSinkConnectorConfig.DISALLOW_PRIVATE_IPS)) {
@@ -386,11 +386,6 @@ public class InternalUtils {
       }
     }
 
-    if (conf.containsKey(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS)) {
-      proxyProperties.put(
-          SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS,
-          conf.get(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS));
-    }
 
     return proxyProperties;
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -356,6 +356,12 @@ public class InternalUtils {
         proxyProperties.put(SFSessionProperty.PROXY_USER.getPropertyKey(), username);
         proxyProperties.put(SFSessionProperty.PROXY_PASSWORD.getPropertyKey(), password);
       }
+
+      // Add disallow local IPs config if present
+      String disallowLocalIps = conf.get(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS);
+      if (disallowLocalIps != null) {
+        proxyProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS, disallowLocalIps);
+      }
     }
     return proxyProperties;
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -699,8 +699,10 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
         String expectedPipeDefinition = pipeDefinition(tableName, stageName);
         compatible = definition.equalsIgnoreCase(expectedPipeDefinition);
         if (!compatible) {
-          LOGGER.error("Pipe definition '{}' is not same as expected definition '{}'",
-              definition, expectedPipeDefinition);
+          LOGGER.error(
+              "Pipe definition '{}' is not same as expected definition '{}'",
+              definition,
+              expectedPipeDefinition);
         }
       }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -1170,7 +1170,8 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
             fullPipeName,
             privateKey,
             userAgentSuffixInHttpRequest,
-            telemetry)
+            telemetry,
+            jdbcProperties.getProxyProperties())
         .build();
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeIngestionServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeIngestionServiceFactory.java
@@ -2,6 +2,7 @@ package com.snowflake.kafka.connector.internal;
 
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import java.security.PrivateKey;
+import java.util.Properties;
 import javax.annotation.Nullable;
 
 /** A factory to create {@link SnowflakeIngestionService} */
@@ -31,6 +32,32 @@ public class SnowflakeIngestionServiceFactory {
         telemetry);
   }
 
+  public static SnowflakeIngestionServiceBuilder builder(
+      String accountName,
+      String userName,
+      String host,
+      int port,
+      String connectionScheme,
+      String stageName,
+      String pipeName,
+      PrivateKey privateKey,
+      String userAgentSuffix,
+      SnowflakeTelemetryService telemetry,
+      Properties proxyProperties) {
+    return new SnowflakeIngestionServiceBuilder(
+        accountName,
+        userName,
+        host,
+        port,
+        connectionScheme,
+        stageName,
+        pipeName,
+        privateKey,
+        userAgentSuffix,
+        telemetry,
+        proxyProperties);
+  }
+
   /** Builder class to create instance of {@link SnowflakeIngestionService} */
   static class SnowflakeIngestionServiceBuilder {
     private final SnowflakeIngestionService service;
@@ -58,6 +85,33 @@ public class SnowflakeIngestionServiceFactory {
               privateKey,
               userAgentSuffix,
               telemetry);
+    }
+
+    private SnowflakeIngestionServiceBuilder(
+        String accountName,
+        String userName,
+        String host,
+        int port,
+        String connectionScheme,
+        String stageName,
+        String pipeName,
+        PrivateKey privateKey,
+        String userAgentSuffix,
+        @Nullable SnowflakeTelemetryService telemetry,
+        Properties proxyProperties) {
+      this.service =
+          new SnowflakeIngestionServiceV1(
+              accountName,
+              userName,
+              host,
+              port,
+              connectionScheme,
+              stageName,
+              pipeName,
+              privateKey,
+              userAgentSuffix,
+              telemetry,
+              proxyProperties);
     }
 
     SnowflakeIngestionServiceBuilder setTelemetry(SnowflakeTelemetryService telemetry) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeIngestionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeIngestionServiceV1.java
@@ -69,6 +69,37 @@ public class SnowflakeIngestionServiceV1 implements SnowflakeIngestionService {
     LOGGER.info("initialized the pipe connector for pipe {}", pipeName);
   }
 
+  SnowflakeIngestionServiceV1(
+      String accountName,
+      String userName,
+      String host,
+      int port,
+      String connectionScheme,
+      String stageName,
+      String pipeName,
+      PrivateKey privateKey,
+      String userAgentSuffix,
+      @Nullable SnowflakeTelemetryService telemetry,
+      Properties proxyProperties) {
+
+    this(
+        stageName,
+        pipeName,
+        createOrThrow(
+            accountName,
+            userName,
+            host,
+            port,
+            connectionScheme,
+            pipeName,
+            privateKey,
+            userAgentSuffix,
+            telemetry,
+            proxyProperties),
+        telemetry);
+    LOGGER.info("initialized the pipe connector for pipe {}", pipeName);
+  }
+
   @VisibleForTesting
   SnowflakeIngestionServiceV1(
       String stageName,
@@ -101,6 +132,33 @@ public class SnowflakeIngestionServiceV1 implements SnowflakeIngestionService {
           host,
           port,
           userAgentSuffix);
+    } catch (Exception e) {
+      throw SnowflakeErrors.ERROR_0002.getException(e, telemetry);
+    }
+  }
+
+  private static SimpleIngestManager createOrThrow(
+      String accountName,
+      String userName,
+      String host,
+      int port,
+      String connectionScheme,
+      String pipeName,
+      PrivateKey privateKey,
+      String userAgentSuffix,
+      SnowflakeTelemetryService telemetry,
+      Properties proxyProperties) {
+    try {
+      return new SimpleIngestManager(
+          accountName,
+          userName,
+          pipeName,
+          privateKey,
+          connectionScheme,
+          host,
+          port,
+          userAgentSuffix,
+          proxyProperties);
     } catch (Exception e) {
       throw SnowflakeErrors.ERROR_0002.getException(e, telemetry);
     }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -2,7 +2,6 @@ package com.snowflake.kafka.connector.internal;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED;
 import static com.snowflake.kafka.connector.Utils.createNamedThreadFactory;
-import static com.snowflake.kafka.connector.config.TopicToTableModeExtractor.determineTopic2TableMode;
 import static com.snowflake.kafka.connector.internal.FileNameUtils.searchForMissingOffsets;
 import static com.snowflake.kafka.connector.internal.metrics.MetricsUtil.BUFFER_RECORD_COUNT;
 import static com.snowflake.kafka.connector.internal.metrics.MetricsUtil.BUFFER_SIZE_BYTES;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
@@ -295,7 +295,7 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
     }
 
     // Open channel and reset the offset in kafka
-    this.channel = Preconditions.checkNotNull(openChannelForTable());
+    this.channel = Preconditions.checkNotNull(openChannelForTable(this.enableSchemaEvolution));
     final long lastCommittedOffsetToken = fetchOffsetTokenWithRetry();
     this.offsetPersistedInSnowflake.set(lastCommittedOffsetToken);
     this.processedOffset.set(lastCommittedOffsetToken);
@@ -963,7 +963,7 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
       final StreamingApiFallbackInvoker streamingApiFallbackInvoker) {
     LOGGER.warn(
         "{} Re-opening channel:{}", streamingApiFallbackInvoker, this.getChannelNameFormatV1());
-    return Preconditions.checkNotNull(openChannelForTable());
+    return Preconditions.checkNotNull(openChannelForTable(this.enableSchemaEvolution));
   }
 
   /**
@@ -1016,13 +1016,18 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
    *
    * @return new channel which was fetched after open/reopen
    */
-  private SnowflakeStreamingIngestChannel openChannelForTable() {
+  private SnowflakeStreamingIngestChannel openChannelForTable(boolean schemaEvolutionEnabled) {
+    OpenChannelRequest.OnErrorOption onErrorOption =
+            schemaEvolutionEnabled
+                    ? OpenChannelRequest.OnErrorOption.SKIP_BATCH
+                    : OpenChannelRequest.OnErrorOption.CONTINUE;
+
     OpenChannelRequest channelRequest =
         OpenChannelRequest.builder(this.channelNameFormatV1)
             .setDBName(this.sfConnectorConfig.get(Utils.SF_DATABASE))
             .setSchemaName(this.sfConnectorConfig.get(Utils.SF_SCHEMA))
             .setTableName(this.tableName)
-            .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
+            .setOnErrorOption(onErrorOption)
             .setOffsetTokenVerificationFunction(StreamingUtils.offsetTokenVerificationFunction)
             .build();
     LOGGER.info(

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -157,6 +157,14 @@ public class StreamingUtils {
 
     // todo: add the proxy related configs here
 
+    // Add disallow local IPs config if present
+    connectorConfig.computeIfPresent(
+        SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS,
+        (key, value) -> {
+          streamingProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS, value);
+          return value;
+        });
+
     return streamingProperties;
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -5,12 +5,11 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ErrorTolerance;
 
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
-import net.snowflake.client.core.SFSessionProperty;
 import net.snowflake.ingest.streaming.OffsetTokenVerificationFunction;
 import net.snowflake.ingest.utils.Constants;
 import org.apache.kafka.common.record.DefaultRecord;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -154,7 +154,6 @@ public class StreamingUtils {
           return value;
         });
 
-    // todo: add the proxy related configs here
 
     // Add disallow local IPs config if present
     connectorConfig.computeIfPresent(
@@ -178,12 +177,14 @@ public class StreamingUtils {
           streamingProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_CLASS_E_IPS, value);
           return value;
         });
+
     connectorConfig.computeIfPresent(
         SnowflakeSinkConnectorConfig.DISALLOW_CIDR_RANGES,
         (key, value) -> {
           streamingProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_CIDR_RANGES, value);
           return value;
         });
+
     connectorConfig.computeIfPresent(
         SnowflakeSinkConnectorConfig.ALLOW_CIDR_RANGES,
         (key, value) -> {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -9,6 +9,8 @@ import com.snowflake.kafka.connector.Utils;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import net.snowflake.client.core.SFSessionProperty;
 import net.snowflake.ingest.streaming.OffsetTokenVerificationFunction;
 import net.snowflake.ingest.utils.Constants;
 import org.apache.kafka.common.record.DefaultRecord;
@@ -152,6 +154,8 @@ public class StreamingUtils {
           streamingProperties.put(STREAMING_CONSTANT_OAUTH_TOKEN_ENDPOINT, value);
           return value;
         });
+
+    // todo: add the proxy related configs here
 
     return streamingProperties;
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -10,6 +10,8 @@ import com.snowflake.kafka.connector.Utils;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Properties;
+
+import net.snowflake.client.core.SFSessionProperty;
 import net.snowflake.ingest.streaming.OffsetTokenVerificationFunction;
 import net.snowflake.ingest.utils.Constants;
 import org.apache.kafka.common.record.DefaultRecord;
@@ -154,6 +156,44 @@ public class StreamingUtils {
           return value;
         });
 
+    connectorConfig.computeIfPresent(
+            SnowflakeSinkConnectorConfig.SNOWFLAKE_USE_HTTPS_PROXY,
+            (key, value) -> {
+              streamingProperties.put(SFSessionProperty.USE_PROXY.getPropertyKey(), value);
+              return value;
+            });
+    connectorConfig.computeIfPresent(
+            SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_HOST,
+            (key, value) -> {
+              streamingProperties.put(SFSessionProperty.PROXY_HOST.getPropertyKey(), value);
+              return value;
+            });
+
+    connectorConfig.computeIfPresent(
+            SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_PORT,
+            (key, value) -> {
+              streamingProperties.put(SFSessionProperty.PROXY_PORT.getPropertyKey(), value);
+              return value;
+            });
+
+    connectorConfig.computeIfPresent(
+            SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_NON_PROXY_HOSTS,
+            (key, value) -> {
+              streamingProperties.put(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey(), value);
+              return value;
+            });
+    connectorConfig.computeIfPresent(
+            SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_USER,
+            (key, value) -> {
+              streamingProperties.put(SFSessionProperty.PROXY_USER.getPropertyKey(), value);
+              return value;
+            });
+    connectorConfig.computeIfPresent(
+            SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_PASSWORD,
+            (key, value) -> {
+              streamingProperties.put(SFSessionProperty.PROXY_PASSWORD.getPropertyKey(), value);
+              return value;
+            });
 
     // Add disallow local IPs config if present
     connectorConfig.computeIfPresent(

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -165,6 +165,33 @@ public class StreamingUtils {
           return value;
         });
 
+    // Add disallow private IPs config if present
+    connectorConfig.computeIfPresent(
+        SnowflakeSinkConnectorConfig.DISALLOW_PRIVATE_IPS,
+        (key, value) -> {
+          streamingProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_PRIVATE_IPS, value);
+          return value;
+        });
+
+    connectorConfig.computeIfPresent(
+        SnowflakeSinkConnectorConfig.DISALLOW_CLASS_E_IPS,
+        (key, value) -> {
+          streamingProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_CLASS_E_IPS, value);
+          return value;
+        });
+    connectorConfig.computeIfPresent(
+        SnowflakeSinkConnectorConfig.DISALLOW_CIDR_RANGES,
+        (key, value) -> {
+          streamingProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_CIDR_RANGES, value);
+          return value;
+        });
+    connectorConfig.computeIfPresent(
+        SnowflakeSinkConnectorConfig.ALLOW_CIDR_RANGES,
+        (key, value) -> {
+          streamingProperties.put(SnowflakeSinkConnectorConfig.ALLOW_CIDR_RANGES, value);
+          return value;
+        });
+
     return streamingProperties;
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeTableStreamingRecordMapper.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeTableStreamingRecordMapper.java
@@ -7,13 +7,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
 class SnowflakeTableStreamingRecordMapper extends StreamingRecordMapper {
-
+  private final KCLogger LOGGER = new KCLogger(RecordService.class.getName());
   public SnowflakeTableStreamingRecordMapper(ObjectMapper mapper, boolean schematizationEnabled) {
     super(mapper, schematizationEnabled);
   }
@@ -25,7 +26,16 @@ class SnowflakeTableStreamingRecordMapper extends StreamingRecordMapper {
     final Map<String, Object> streamingIngestRow = new HashMap<>();
     for (JsonNode node : row.getContent().getData()) {
       if (schematizationEnabled) {
-        streamingIngestRow.putAll(getMapFromJsonNodeForStreamingIngest(node));
+        try {
+          streamingIngestRow.putAll(getMapFromJsonNodeForStreamingIngest(node));
+        } catch (StringIndexOutOfBoundsException e) {
+          LOGGER.trace("Record data that caused StringIndexOutOfBoundsException: {}", node.toString());
+          LOGGER.info("StringIndexOutOfBoundsException occurred while processing record, metadata " +
+                  mapper.writeValueAsString(row.getMetadata()));
+
+          throw SnowflakeErrors.ERROR_0010.getException(
+                  "Invalid column name encountered during streaming ingest processing: " + e.getMessage());
+        }
       } else {
         streamingIngestRow.put(TABLE_COLUMN_CONTENT, mapper.writeValueAsString(node));
       }

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -7,7 +7,6 @@ import static com.snowflake.kafka.connector.internal.TestUtils.getConf;
 import static com.snowflake.kafka.connector.internal.TestUtils.getConfWithOAuth;
 import static org.junit.Assert.assertEquals;
 
-import com.snowflake.kafka.connector.internal.TestUtils;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
@@ -153,7 +153,8 @@ public class SinkTaskProxyIT {
 
     // Test data ingestion
     String file = "{\"aa\":123}";
-    String fileName = FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 1);
+    String fileName =
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 1);
 
     connectionService.putWithCache(stage, fileName, file);
     ingestionService.ingestFile(fileName);
@@ -198,7 +199,8 @@ public class SinkTaskProxyIT {
 
     // Test data ingestion
     String file = "{\"aa\":123}";
-    String fileName = FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 1);
+    String fileName =
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 1);
 
     connectionService.putWithCache(stage, fileName, file);
     ingestionService.ingestFile(fileName);

--- a/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
@@ -71,6 +71,9 @@ public class SinkTaskProxyIT {
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "3128");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME, "admin");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD, "test");
+    config.put(SnowflakeSinkConnectorConfig.DISALLOW_LOCAL_IPS, "false");
+    config.put(SnowflakeSinkConnectorConfig.DISALLOW_PRIVATE_IPS, "false");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_USE_HTTPS_PROXY, "true");
     SnowflakeSinkTask sinkTask = new SnowflakeSinkTask();
 
     sinkTask.start(config);

--- a/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
@@ -15,6 +15,13 @@ public class SinkTaskProxyIT {
   @After
   public void testCleanup() {
     TestUtils.resetProxyParametersInJVM();
+    // Reset JVM proxy properties
+    System.clearProperty(Utils.HTTP_USE_PROXY);
+    System.clearProperty(Utils.HTTPS_PROXY_HOST);
+    System.clearProperty(Utils.HTTPS_PROXY_PORT);
+    System.clearProperty(Utils.HTTP_PROXY_HOST);
+    System.clearProperty(Utils.HTTP_PROXY_PORT);
+    System.clearProperty(Utils.HTTP_NON_PROXY_HOSTS);
   }
 
   @Test(expected = SnowflakeKafkaConnectorException.class)
@@ -100,6 +107,98 @@ public class SinkTaskProxyIT {
     String file = "{\"aa\":123}";
     String fileName =
         FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 1);
+
+    connectionService.putWithCache(stage, fileName, file);
+    ingestionService.ingestFile(fileName);
+    List<String> names = new ArrayList<>(1);
+    names.add(fileName);
+  }
+
+  /**
+   * Test Snowflake-specific proxy configuration with authentication. Requires a proxy server
+   * running at localhost:3128 with authentication.
+   */
+  @Test
+  public void testSnowflakeProxyConfig() {
+    Map<String, String> config = TestUtils.getConf();
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+
+    // Configure Snowflake-specific proxy settings
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_USE_HTTPS_PROXY, "true");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_HOST, "localhost");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_PORT, "3128");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_USER, "admin");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_PASSWORD, "test");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_NON_PROXY_HOSTS, "localhost,127.0.0.1");
+
+    SnowflakeSinkTask sinkTask = new SnowflakeSinkTask();
+    sinkTask.start(config);
+
+    // Test actual Snowflake operations through proxy
+    Optional<SnowflakeConnectionService> optSfConnectionService = sinkTask.getSnowflakeConnection();
+    Assert.assertTrue(optSfConnectionService.isPresent());
+
+    SnowflakeConnectionService connectionService = optSfConnectionService.get();
+
+    String stage = TestUtils.randomStageName();
+    String pipe = TestUtils.randomPipeName();
+    String table = TestUtils.randomTableName();
+
+    // Test basic Snowflake operations
+    connectionService.createStage(stage);
+    connectionService.createTable(table);
+    connectionService.createPipe(table, stage, pipe);
+
+    SnowflakeIngestionService ingestionService = connectionService.buildIngestService(stage, pipe);
+
+    // Test data ingestion
+    String file = "{\"aa\":123}";
+    String fileName = FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 1);
+
+    connectionService.putWithCache(stage, fileName, file);
+    ingestionService.ingestFile(fileName);
+    List<String> names = new ArrayList<>(1);
+    names.add(fileName);
+  }
+
+  /**
+   * Test Snowflake-specific proxy configuration without authentication. Requires a proxy server
+   * running at localhost:3128 without authentication.
+   */
+  @Test
+  public void testSnowflakeProxyConfigWithoutAuth() {
+    Map<String, String> config = TestUtils.getConf();
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+
+    // Configure Snowflake-specific proxy settings without auth
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_USE_HTTPS_PROXY, "true");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_HOST, "localhost");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_PORT, "3128");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_NON_PROXY_HOSTS, "localhost,127.0.0.1");
+
+    SnowflakeSinkTask sinkTask = new SnowflakeSinkTask();
+    sinkTask.start(config);
+
+    // Test actual Snowflake operations through proxy
+    Optional<SnowflakeConnectionService> optSfConnectionService = sinkTask.getSnowflakeConnection();
+    Assert.assertTrue(optSfConnectionService.isPresent());
+
+    SnowflakeConnectionService connectionService = optSfConnectionService.get();
+
+    String stage = TestUtils.randomStageName();
+    String pipe = TestUtils.randomPipeName();
+    String table = TestUtils.randomTableName();
+
+    // Test basic Snowflake operations
+    connectionService.createStage(stage);
+    connectionService.createTable(table);
+    connectionService.createPipe(table, stage, pipe);
+
+    SnowflakeIngestionService ingestionService = connectionService.buildIngestService(stage, pipe);
+
+    // Test data ingestion
+    String file = "{\"aa\":123}";
+    String fileName = FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 1);
 
     connectionService.putWithCache(stage, fileName, file);
     ingestionService.ingestFile(fileName);

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeProxyConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeProxyConfigTest.java
@@ -1,0 +1,134 @@
+package com.snowflake.kafka.connector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.snowflake.kafka.connector.internal.InternalUtils;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import net.snowflake.client.core.SFSessionProperty;
+import org.junit.Test;
+
+public class SnowflakeProxyConfigTest {
+
+  @Test
+  public void testSnowflakeProxyConfigValidation() {
+    Map<String, String> config = new HashMap<>();
+
+    // Test valid config with host and port
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_USE_HTTPS_PROXY, "true");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_HOST, "proxy.example.com");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_PORT, "8080");
+
+    Properties proxyProps = InternalUtils.generateProxyParametersIfRequired(config);
+    assertTrue(proxyProps.containsKey(SFSessionProperty.USE_PROXY.getPropertyKey()));
+    assertEquals("true", proxyProps.getProperty(SFSessionProperty.USE_PROXY.getPropertyKey()));
+    assertEquals(
+        "proxy.example.com", proxyProps.getProperty(SFSessionProperty.PROXY_HOST.getPropertyKey()));
+    assertEquals("8080", proxyProps.getProperty(SFSessionProperty.PROXY_PORT.getPropertyKey()));
+
+    // Test missing host
+    config.remove(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_HOST);
+    proxyProps = InternalUtils.generateProxyParametersIfRequired(config);
+    assertFalse(proxyProps.containsKey(SFSessionProperty.USE_PROXY.getPropertyKey()));
+
+    // Test missing port
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_HOST, "proxy.example.com");
+    config.remove(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_PORT);
+    proxyProps = InternalUtils.generateProxyParametersIfRequired(config);
+    assertFalse(proxyProps.containsKey(SFSessionProperty.USE_PROXY.getPropertyKey()));
+  }
+
+  @Test
+  public void testSnowflakeProxyWithAuth() {
+    Map<String, String> config = new HashMap<>();
+
+    // Test with auth credentials
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_USE_HTTPS_PROXY, "true");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_HOST, "proxy.example.com");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_PORT, "8080");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_USER, "proxyuser");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_PASSWORD, "proxypass");
+
+    Properties proxyProps = InternalUtils.generateProxyParametersIfRequired(config);
+    assertTrue(proxyProps.containsKey(SFSessionProperty.PROXY_USER.getPropertyKey()));
+    assertTrue(proxyProps.containsKey(SFSessionProperty.PROXY_PASSWORD.getPropertyKey()));
+    assertEquals(
+        "proxyuser", proxyProps.getProperty(SFSessionProperty.PROXY_USER.getPropertyKey()));
+    assertEquals(
+        "proxypass", proxyProps.getProperty(SFSessionProperty.PROXY_PASSWORD.getPropertyKey()));
+
+    // Test missing password
+    config.remove(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_PASSWORD);
+    proxyProps = InternalUtils.generateProxyParametersIfRequired(config);
+    assertFalse(proxyProps.containsKey(SFSessionProperty.PROXY_USER.getPropertyKey()));
+    assertFalse(proxyProps.containsKey(SFSessionProperty.PROXY_PASSWORD.getPropertyKey()));
+  }
+
+  @Test
+  public void testSnowflakeProxyNonProxyHosts() {
+    Map<String, String> config = new HashMap<>();
+
+    // Test with non-proxy hosts
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_USE_HTTPS_PROXY, "true");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_HOST, "proxy.example.com");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_PORT, "8080");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_NON_PROXY_HOSTS, "localhost,127.0.0.1");
+
+    Properties proxyProps = InternalUtils.generateProxyParametersIfRequired(config);
+    assertTrue(proxyProps.containsKey(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey()));
+    assertEquals(
+        "localhost,127.0.0.1",
+        proxyProps.getProperty(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey()));
+  }
+
+  @Test
+  public void testSnowflakeProxyPropertyGeneration() {
+    Map<String, String> config = new HashMap<>();
+
+    // Test complete proxy configuration
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_USE_HTTPS_PROXY, "true");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_HOST, "proxy.example.com");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_PORT, "8080");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_USER, "proxyuser");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_PASSWORD, "proxypass");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_NON_PROXY_HOSTS, "localhost,127.0.0.1");
+
+    Properties proxyProps = InternalUtils.generateProxyParametersIfRequired(config);
+
+    // Verify all properties are set correctly
+    assertEquals("true", proxyProps.getProperty(SFSessionProperty.USE_PROXY.getPropertyKey()));
+    assertEquals(
+        "proxy.example.com", proxyProps.getProperty(SFSessionProperty.PROXY_HOST.getPropertyKey()));
+    assertEquals("8080", proxyProps.getProperty(SFSessionProperty.PROXY_PORT.getPropertyKey()));
+    assertEquals(
+        "proxyuser", proxyProps.getProperty(SFSessionProperty.PROXY_USER.getPropertyKey()));
+    assertEquals(
+        "proxypass", proxyProps.getProperty(SFSessionProperty.PROXY_PASSWORD.getPropertyKey()));
+    assertEquals(
+        "localhost,127.0.0.1",
+        proxyProps.getProperty(SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey()));
+  }
+
+  @Test
+  public void testSnowflakeProxyPropertyGenerationWithoutAuth() {
+    Map<String, String> config = new HashMap<>();
+
+    // Test proxy configuration without auth
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_USE_HTTPS_PROXY, "true");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_HOST, "proxy.example.com");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_HTTPS_PROXY_PORT, "8080");
+
+    Properties proxyProps = InternalUtils.generateProxyParametersIfRequired(config);
+
+    // Verify only non-auth properties are set
+    assertEquals("true", proxyProps.getProperty(SFSessionProperty.USE_PROXY.getPropertyKey()));
+    assertEquals(
+        "proxy.example.com", proxyProps.getProperty(SFSessionProperty.PROXY_HOST.getPropertyKey()));
+    assertEquals("8080", proxyProps.getProperty(SFSessionProperty.PROXY_PORT.getPropertyKey()));
+    assertFalse(proxyProps.containsKey(SFSessionProperty.PROXY_USER.getPropertyKey()));
+    assertFalse(proxyProps.containsKey(SFSessionProperty.PROXY_PASSWORD.getPropertyKey()));
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/config/SnowflakeSinkConnectorConfigBuilder.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SnowflakeSinkConnectorConfigBuilder.java
@@ -34,7 +34,8 @@ public class SnowflakeSinkConnectorConfigBuilder {
     return commonRequiredFields()
         .withIcebergEnabled()
         .withIngestionMethod(IngestionMethodConfig.SNOWPIPE_STREAMING)
-        .withSchematizationEnabled(true);
+        .withSchematizationEnabled(true)
+        .withSingleBufferEnabled(true);
   }
 
   private static SnowflakeSinkConnectorConfigBuilder commonRequiredFields() {

--- a/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
@@ -822,7 +822,6 @@ public class SinkServiceIT {
     // to 3.
     List<String> files = conn.listStage(table, "", true);
     assert files.size() == expectedTableStageSize;
-
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
@@ -822,6 +822,8 @@ public class SinkServiceIT {
     // to 3.
     List<String> files = conn.listStage(table, "", true);
     assert files.size() == expectedTableStageSize;
+
+    service.closeAll();
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -283,12 +283,12 @@ public class TestUtils {
   /* Get configuration map from profile path. Used against prod deployment of Snowflake */
   public static Map<String, String> getConf() {
     Map<String, String> configuration = getConfFromFileName(PROFILE_PATH);
-    
+
     // Disable connection restrictions for tests to allow localhost connections
     configuration.put("connection.disallow.local.ips", "false");
     configuration.put("connection.disallow.private.ips", "false");
     configuration.put("connection.disallow.class.e.ips", "false");
-    
+
     return configuration;
   }
 
@@ -303,7 +303,7 @@ public class TestUtils {
     configuration.put(
         SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
         IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    
+
     // Disable connection restrictions for tests to allow localhost connections
     configuration.put("connection.disallow.local.ips", "false");
     configuration.put("connection.disallow.private.ips", "false");
@@ -362,7 +362,7 @@ public class TestUtils {
     config.remove(Utils.SF_PRIVATE_KEY);
     config.put(Utils.SF_PRIVATE_KEY, getEncryptedPrivateKey());
     config.put(Utils.PRIVATE_KEY_PASSPHRASE, getPrivateKeyPassphrase());
-    
+
     // Disable connection restrictions for tests to allow localhost connections
     config.put("connection.disallow.local.ips", "false");
     config.put("connection.disallow.private.ips", "false");

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -282,7 +282,14 @@ public class TestUtils {
 
   /* Get configuration map from profile path. Used against prod deployment of Snowflake */
   public static Map<String, String> getConf() {
-    return getConfFromFileName(PROFILE_PATH);
+    Map<String, String> configuration = getConfFromFileName(PROFILE_PATH);
+    
+    // Disable connection restrictions for tests to allow localhost connections
+    configuration.put("connection.disallow.local.ips", "false");
+    configuration.put("connection.disallow.private.ips", "false");
+    configuration.put("connection.disallow.class.e.ips", "false");
+    
+    return configuration;
   }
 
   /* Get configuration map from profile path. Used against prod deployment of Snowflake */
@@ -296,6 +303,11 @@ public class TestUtils {
     configuration.put(
         SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
         IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    
+    // Disable connection restrictions for tests to allow localhost connections
+    configuration.put("connection.disallow.local.ips", "false");
+    configuration.put("connection.disallow.private.ips", "false");
+    configuration.put("connection.disallow.class.e.ips", "false");
 
     return configuration;
   }
@@ -350,6 +362,11 @@ public class TestUtils {
     config.remove(Utils.SF_PRIVATE_KEY);
     config.put(Utils.SF_PRIVATE_KEY, getEncryptedPrivateKey());
     config.put(Utils.PRIVATE_KEY_PASSPHRASE, getPrivateKeyPassphrase());
+    
+    // Disable connection restrictions for tests to allow localhost connections
+    config.put("connection.disallow.local.ips", "false");
+    config.put("connection.disallow.private.ips", "false");
+    config.put("connection.disallow.class.e.ips", "false");
 
     return config;
   }

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -283,12 +283,10 @@ public class TestUtils {
   /* Get configuration map from profile path. Used against prod deployment of Snowflake */
   public static Map<String, String> getConf() {
     Map<String, String> configuration = getConfFromFileName(PROFILE_PATH);
-
     // Disable connection restrictions for tests to allow localhost connections
     configuration.put("connection.disallow.local.ips", "false");
     configuration.put("connection.disallow.private.ips", "false");
     configuration.put("connection.disallow.class.e.ips", "false");
-
     return configuration;
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -124,10 +124,11 @@ public class SnowflakeSinkServiceV2IT {
         });
   }
 
-  @Test
-  public void testChannelCloseIngestion() throws Exception {
+  @ParameterizedTest(name = "useSingleBuffer: {0}")
+  @MethodSource("singleBufferParameters")
+  public void testChannelCloseIngestion(boolean useSingleBuffer) throws Exception {
     conn = getConn(false);
-    Map<String, String> config = getConfig(false, false);
+    Map<String, String> config = getConfig(false, useSingleBuffer);
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     conn.createTable(table);
     // opens a channel for partition 0, table and topic
@@ -135,6 +136,7 @@ public class SnowflakeSinkServiceV2IT {
         StreamingSinkServiceBuilder.builder(conn, config)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .build();
+    service.setRecordNumber(1);
     service.startPartition(table, new TopicPartition(topic, partition));
 
     SnowflakeConverter converter = new SnowflakeJsonConverter();
@@ -166,10 +168,11 @@ public class SnowflakeSinkServiceV2IT {
     service.closeAll();
   }
 
-  @Test
-  public void testRebalanceOpenCloseIngestion() throws Exception {
+  @ParameterizedTest(name = "useSingleBuffer: {0}")
+  @MethodSource("singleBufferParameters")
+  public void testRebalanceOpenCloseIngestion(boolean useSingleBuffer) throws Exception {
     conn = getConn(false);
-    Map<String, String> config = getConfig(false, false);
+    Map<String, String> config = getConfig(false, useSingleBuffer);
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     conn.createTable(table);
     // opens a channel for partition 0, table and topic
@@ -177,6 +180,7 @@ public class SnowflakeSinkServiceV2IT {
         StreamingSinkServiceBuilder.builder(conn, config)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .build();
+    service.setRecordNumber(1);
     service.startPartition(table, new TopicPartition(topic, partition));
 
     SnowflakeConverter converter = new SnowflakeJsonConverter();
@@ -209,10 +213,11 @@ public class SnowflakeSinkServiceV2IT {
     service.closeAll();
   }
 
-  @Test
-  public void testStreamingIngestion() throws Exception {
+  @ParameterizedTest(name = "useSingleBuffer: {0}")
+  @MethodSource("singleBufferParameters")
+  public void testStreamingIngestion(boolean useSingleBuffer) throws Exception {
     conn = getConn(false);
-    Map<String, String> config = getConfig(false, false);
+    Map<String, String> config = getConfig(false, useSingleBuffer);
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     conn.createTable(table);
     // opens a channel for partition 0, table and topic
@@ -220,6 +225,7 @@ public class SnowflakeSinkServiceV2IT {
         StreamingSinkServiceBuilder.builder(conn, config)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .build();
+    service.setRecordNumber(1);
     service.startPartition(table, new TopicPartition(topic, partition));
 
     SnowflakeConverter converter = new SnowflakeJsonConverter();
@@ -271,10 +277,11 @@ public class SnowflakeSinkServiceV2IT {
     service.closeAll();
   }
 
-  @Test
-  public void testStreamingIngest_multipleChannelPartitions_withMetrics() throws Exception {
+  @ParameterizedTest(name = "useSingleBuffer: {0}")
+  @MethodSource("singleBufferParameters")
+  public void testStreamingIngest_multipleChannelPartitions_withMetrics(boolean useSingleBuffer) throws Exception {
     conn = getConn(false);
-    Map<String, String> config = getConfig(false, false);
+    Map<String, String> config = getConfig(false, useSingleBuffer);
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     conn.createTable(table);
     // set up telemetry service spy
@@ -628,6 +635,7 @@ public class SnowflakeSinkServiceV2IT {
         StreamingSinkServiceBuilder.builder(conn, config)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .build();
+    service.setRecordNumber(1);
     service.startPartition(table, new TopicPartition(topic, partition));
 
     service.insert(noSchemaRecordValue);
@@ -793,6 +801,7 @@ public class SnowflakeSinkServiceV2IT {
         StreamingSinkServiceBuilder.builder(conn, config)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .build();
+    service.setRecordNumber(1);
     service.startPartition(table, new TopicPartition(topic, partition));
 
     service.insert(avroRecordValue);
@@ -855,6 +864,7 @@ public class SnowflakeSinkServiceV2IT {
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .withErrorReporter(errorReporter)
             .build();
+    service.setRecordNumber(1);
     service.startPartition(table, new TopicPartition(topic, partition));
 
     service.insert(brokenValue);
@@ -911,6 +921,7 @@ public class SnowflakeSinkServiceV2IT {
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .withErrorReporter(errorReporter)
             .build();
+    service.setRecordNumber(1);
     service.startPartition(table, new TopicPartition(topic, partition));
 
     service.insert(brokenValue);
@@ -973,6 +984,7 @@ public class SnowflakeSinkServiceV2IT {
             .withErrorReporter(errorReporter)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .build();
+    service.setRecordNumber(1);
     service.startPartition(table, new TopicPartition(topic, partition));
 
     service.insert(correctValue);
@@ -1007,6 +1019,7 @@ public class SnowflakeSinkServiceV2IT {
         StreamingSinkServiceBuilder.builder(conn, config)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .build();
+    service.setRecordNumber(1);
     service.startPartition(table, new TopicPartition(topic, partition));
 
     SnowflakeConverter converter = new SnowflakeJsonConverter();
@@ -1036,6 +1049,7 @@ public class SnowflakeSinkServiceV2IT {
             .setSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .addTask(table, new TopicPartition(topic, partition))
             .build();
+    service2.setRecordNumber(1);
     offset = 1;
     // Create sink record
     SinkRecord record2 =
@@ -1066,6 +1080,7 @@ public class SnowflakeSinkServiceV2IT {
         StreamingSinkServiceBuilder.builder(conn, config)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .build();
+    service.setRecordNumber(1);
     service.startPartition(table, new TopicPartition(topic, partition));
 
     SnowflakeConverter converter = new SnowflakeJsonConverter();
@@ -1093,6 +1108,7 @@ public class SnowflakeSinkServiceV2IT {
         StreamingSinkServiceBuilder.builder(conn, config)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .build();
+    service2.setRecordNumber(1);
     service2.startPartition(table, new TopicPartition(topic, partition));
 
     final long startOffsetAlreadyInserted = 5;
@@ -1177,6 +1193,7 @@ public class SnowflakeSinkServiceV2IT {
         StreamingSinkServiceBuilder.builder(conn, config)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .build();
+    service.setRecordNumber(1);
     service.startPartition(table, new TopicPartition(topic, partition));
 
     // The first insert should fail and schema evolution will kick in to update the schema
@@ -1248,6 +1265,7 @@ public class SnowflakeSinkServiceV2IT {
         StreamingSinkServiceBuilder.builder(conn, config)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .build();
+    service.setRecordNumber(1);
     service.startPartition(table, new TopicPartition(topic, partition));
 
     // The first insert should fail and schema evolution will kick in to add the column
@@ -1301,6 +1319,7 @@ public class SnowflakeSinkServiceV2IT {
         StreamingSinkServiceBuilder.builder(conn, config)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .build();
+    service.setRecordNumber(1);
     service.startPartition(table, new TopicPartition(topic, partition));
 
     final long noOfRecords = 50;
@@ -1496,18 +1515,21 @@ public class SnowflakeSinkServiceV2IT {
         StreamingSinkServiceBuilder.builder(catConn, catConfig)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(catTp)))
             .build();
+    catService.setRecordNumber(1);
     catService.startPartition(catTopic, catTp);
 
     SnowflakeSinkService dogService =
         StreamingSinkServiceBuilder.builder(dogConn, dogConfig)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(dogTp)))
             .build();
+    dogService.setRecordNumber(1);
     dogService.startPartition(dogTopic, dogTp);
 
     SnowflakeSinkService fishService =
         StreamingSinkServiceBuilder.builder(fishConn, fishConfig)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(fishTp)))
             .build();
+    fishService.setRecordNumber(1);
     fishService.startPartition(fishTopic, fishTp);
 
     // create records
@@ -1568,7 +1590,7 @@ public class SnowflakeSinkServiceV2IT {
     long assertionSleepTimeMs = 6 * 1000L;
 
     conn = getConn(false);
-    Map<String, String> config = TestUtils.getConfForStreaming();
+    Map<String, String> config = getConfig(false, true);
     config.put(ENABLE_SCHEMATIZATION_CONFIG, "true");
     config.put(
         SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD,

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -37,8 +37,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
@@ -48,7 +48,6 @@ import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -167,7 +166,6 @@ public class SnowflakeSinkServiceV2IT {
     service.closeAll();
   }
 
-
   @Test
   public void testRebalanceOpenCloseIngestion() throws Exception {
     conn = getConn(false);
@@ -283,15 +281,15 @@ public class SnowflakeSinkServiceV2IT {
     SnowflakeConnectionService connectionService = Mockito.spy(this.conn);
     connectionService.createTable(table);
     SnowflakeTelemetryServiceV2 telemetryService =
-            Mockito.spy((SnowflakeTelemetryServiceV2) this.conn.getTelemetryClient());
+        Mockito.spy((SnowflakeTelemetryServiceV2) this.conn.getTelemetryClient());
     Mockito.when(connectionService.getTelemetryClient()).thenReturn(telemetryService);
 
     // opens a channel for partition 0, table and topic
     SnowflakeSinkService service =
-            StreamingSinkServiceBuilder.builder(connectionService, config)
-                    .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
-                    .withEnableCustomJMXMetrics(true)
-                    .build();
+        StreamingSinkServiceBuilder.builder(connectionService, config)
+            .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+            .withEnableCustomJMXMetrics(true)
+            .build();
 
     service.startPartition(table, topicPartition);
     service.startPartition(table, new TopicPartition(topic, partition2));
@@ -299,10 +297,10 @@ public class SnowflakeSinkServiceV2IT {
     final int recordsInPartition1 = 2;
     final int recordsInPartition2 = 5;
     List<SinkRecord> recordsPartition1 =
-            TestUtils.createJsonStringSinkRecords(0, recordsInPartition1, topic, partition);
+        TestUtils.createJsonStringSinkRecords(0, recordsInPartition1, topic, partition);
 
     List<SinkRecord> recordsPartition2 =
-            TestUtils.createJsonStringSinkRecords(0, recordsInPartition2, topic, partition2);
+        TestUtils.createJsonStringSinkRecords(0, recordsInPartition2, topic, partition2);
 
     List<SinkRecord> records = new ArrayList<>(recordsPartition1);
     records.addAll(recordsPartition2);
@@ -310,82 +308,82 @@ public class SnowflakeSinkServiceV2IT {
     service.insert(records);
 
     TestUtils.assertWithRetry(
-            () -> {
-              // This is how we will trigger flush. (Mimicking poll API)
-              service.insert(new ArrayList<>()); // trigger time based flush
-              return TestUtils.tableSize(table) == recordsInPartition1 + recordsInPartition2;
-            },
-            10,
-            20);
+        () -> {
+          // This is how we will trigger flush. (Mimicking poll API)
+          service.insert(new ArrayList<>()); // trigger time based flush
+          return TestUtils.tableSize(table) == recordsInPartition1 + recordsInPartition2;
+        },
+        10,
+        20);
 
     TestUtils.assertWithRetry(
-            () -> service.getOffset(topicPartition) == recordsInPartition1, 20, 5);
+        () -> service.getOffset(topicPartition) == recordsInPartition1, 20, 5);
     TestUtils.assertWithRetry(
-            () -> service.getOffset(new TopicPartition(topic, partition2)) == recordsInPartition2,
-            20,
-            5);
+        () -> service.getOffset(new TopicPartition(topic, partition2)) == recordsInPartition2,
+        20,
+        5);
 
     // verify all metrics
     Map<String, Gauge> metricRegistry =
-            service
-                    .getMetricRegistry(SnowflakeSinkServiceV2.partitionChannelKey(topic, partition))
-                    .get()
-                    .getGauges();
+        service
+            .getMetricRegistry(SnowflakeSinkServiceV2.partitionChannelKey(topic, partition))
+            .get()
+            .getGauges();
     assert metricRegistry.size()
-            == SnowflakeTelemetryChannelStatus.NUM_METRICS * 2; // two partitions
+        == SnowflakeTelemetryChannelStatus.NUM_METRICS * 2; // two partitions
 
     // partition 1
     verifyPartitionMetrics(
-            metricRegistry,
-            partitionChannelKey(topic, partition),
-            NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE,
-            recordsInPartition1 - 1);
+        metricRegistry,
+        partitionChannelKey(topic, partition),
+        NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE,
+        recordsInPartition1 - 1);
     verifyPartitionMetrics(
-            metricRegistry,
-            partitionChannelKey(topic, partition2),
-            NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE,
-            recordsInPartition2 - 1);
+        metricRegistry,
+        partitionChannelKey(topic, partition2),
+        NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE,
+        recordsInPartition2 - 1);
 
     // verify telemetry
     Mockito.verify(telemetryService, Mockito.times(2))
-            .reportKafkaPartitionStart(Mockito.any(SnowflakeTelemetryChannelCreation.class));
+        .reportKafkaPartitionStart(Mockito.any(SnowflakeTelemetryChannelCreation.class));
 
     service.closeAll();
 
     // verify metrics closed
     assert !service
-            .getMetricRegistry(SnowflakeSinkServiceV2.partitionChannelKey(topic, partition))
-            .isPresent();
+        .getMetricRegistry(SnowflakeSinkServiceV2.partitionChannelKey(topic, partition))
+        .isPresent();
 
     Mockito.verify(telemetryService, Mockito.times(2))
-            .reportKafkaPartitionUsage(
-                    Mockito.any(SnowflakeTelemetryChannelStatus.class), Mockito.eq(true));
+        .reportKafkaPartitionUsage(
+            Mockito.any(SnowflakeTelemetryChannelStatus.class), Mockito.eq(true));
   }
 
   private void verifyPartitionMetrics(
-          Map<String, Gauge> metricRegistry,
-          String partitionChannelKey,
-          long offsetPersistedInSnowflake,
-          long processedOffset) {
+      Map<String, Gauge> metricRegistry,
+      String partitionChannelKey,
+      long offsetPersistedInSnowflake,
+      long processedOffset) {
     // offsets
     assert (long)
             metricRegistry
-                    .get(
-                            MetricsUtil.constructMetricName(
-                                    partitionChannelKey,
-                                    MetricsUtil.OFFSET_SUB_DOMAIN,
-                                    MetricsUtil.OFFSET_PERSISTED_IN_SNOWFLAKE))
-                    .getValue()
-            == offsetPersistedInSnowflake;
+                .get(
+                    MetricsUtil.constructMetricName(
+                        partitionChannelKey,
+                        MetricsUtil.OFFSET_SUB_DOMAIN,
+                        MetricsUtil.OFFSET_PERSISTED_IN_SNOWFLAKE))
+                .getValue()
+        == offsetPersistedInSnowflake;
     assert (long)
             metricRegistry
-                    .get(
-                            MetricsUtil.constructMetricName(
-                                    partitionChannelKey,
-                                    MetricsUtil.OFFSET_SUB_DOMAIN,
-                                    MetricsUtil.PROCESSED_OFFSET))
-                    .getValue()
-            == processedOffset;
+                .get(
+                    MetricsUtil.constructMetricName(
+                        partitionChannelKey,
+                        MetricsUtil.OFFSET_SUB_DOMAIN,
+                        MetricsUtil.PROCESSED_OFFSET))
+                .getValue()
+        == processedOffset;
   }
 
   @ParameterizedTest(name = "useSingleBuffer: {0}")
@@ -510,8 +508,7 @@ public class SnowflakeSinkServiceV2IT {
 
   @ParameterizedTest(name = "useSingleBuffer: {0}")
   @MethodSource("singleBufferParameters")
-  public void testStreamingIngestion_timeBased(boolean useSingleBuffer)
-      throws Exception {
+  public void testStreamingIngestion_timeBased(boolean useSingleBuffer) throws Exception {
     boolean useOAuth = false;
     conn = getConn(useOAuth);
     Map<String, String> config = getConfig(useOAuth, useSingleBuffer);
@@ -547,8 +544,7 @@ public class SnowflakeSinkServiceV2IT {
 
   @ParameterizedTest(name = "useSingleBuffer: {0}")
   @MethodSource("singleBufferParameters")
-  public void testNativeJsonInputIngestion(boolean useSingleBuffer)
-      throws Exception {
+  public void testNativeJsonInputIngestion(boolean useSingleBuffer) throws Exception {
     boolean useOAuth = false;
     conn = getConn(useOAuth);
     Map<String, String> config = getConfig(useOAuth, useSingleBuffer);
@@ -648,8 +644,7 @@ public class SnowflakeSinkServiceV2IT {
 
   @ParameterizedTest(name = "useSingleBuffer: {0}")
   @MethodSource("singleBufferParameters")
-  public void testNativeAvroInputIngestion(boolean useSingleBuffer)
-      throws Exception {
+  public void testNativeAvroInputIngestion(boolean useSingleBuffer) throws Exception {
     boolean useOAuth = false;
     conn = getConn(useOAuth);
     Map<String, String> config = getConfig(useOAuth, useSingleBuffer);
@@ -883,7 +878,8 @@ public class SnowflakeSinkServiceV2IT {
 
   @ParameterizedTest(name = "useSingleBuffer: {0}")
   @MethodSource("singleBufferParameters")
-  public void testBrokenRecordIngestionFollowedUpByValidRecord(boolean useSingleBuffer) throws Exception {
+  public void testBrokenRecordIngestionFollowedUpByValidRecord(boolean useSingleBuffer)
+      throws Exception {
     boolean useOAuth = false;
     conn = getConn(useOAuth);
     Map<String, String> config = getConfig(useOAuth, useSingleBuffer);
@@ -941,8 +937,7 @@ public class SnowflakeSinkServiceV2IT {
    */
   @ParameterizedTest(name = "useSingleBuffer: {0}")
   @MethodSource("singleBufferParameters")
-  public void testBrokenRecordIngestionAfterValidRecord(boolean useSingleBuffer)
-      throws Exception {
+  public void testBrokenRecordIngestionAfterValidRecord(boolean useSingleBuffer) throws Exception {
     boolean useOAuth = false;
     conn = getConn(useOAuth);
     Map<String, String> config = getConfig(useOAuth, useSingleBuffer);
@@ -1294,8 +1289,7 @@ public class SnowflakeSinkServiceV2IT {
 
   @ParameterizedTest(name = "useSingleBuffer: {0}")
   @MethodSource("singleBufferParameters")
-  public void testStreamingIngestionValidClientLag(boolean useSingleBuffer)
-      throws Exception {
+  public void testStreamingIngestionValidClientLag(boolean useSingleBuffer) throws Exception {
     boolean useOAuth = false;
     conn = getConn(useOAuth);
     Map<String, String> config = getConfig(useOAuth, useSingleBuffer);
@@ -1358,7 +1352,8 @@ public class SnowflakeSinkServiceV2IT {
 
   @ParameterizedTest(name = "useSingleBuffer: {0}")
   @MethodSource("singleBufferParameters")
-  public void testStreamingIngestionValidClientPropertiesOverride(boolean useSingleBuffer) throws Exception {
+  public void testStreamingIngestionValidClientPropertiesOverride(boolean useSingleBuffer)
+      throws Exception {
     boolean useOAuth = false;
     conn = getConn(useOAuth);
     Map<String, String> config = new HashMap<>(getConfig(useOAuth, useSingleBuffer));
@@ -1396,7 +1391,8 @@ public class SnowflakeSinkServiceV2IT {
    */
   @ParameterizedTest(name = "useSingleBuffer: {0}")
   @MethodSource("singleBufferParameters")
-  public void testStreamingIngestion_invalidClientPropertiesOverride(boolean useSingleBuffer) throws Exception {
+  public void testStreamingIngestion_invalidClientPropertiesOverride(boolean useSingleBuffer)
+      throws Exception {
     boolean useOAuth = false;
     conn = getConn(useOAuth);
     Map<String, String> config = new HashMap<>(getConfig(useOAuth, useSingleBuffer));

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -1583,14 +1583,15 @@ public class SnowflakeSinkServiceV2IT {
         .containsKey(new StreamingClientProperties(fishConfig));
   }
 
-  @Test
-  void testSkippingOffsetsInSchemaEvolution() throws Exception {
+  @ParameterizedTest(name = "useSingleBuffer: {0}")
+  @MethodSource("singleBufferParameters")
+  void testSkippingOffsetsInSchemaEvolution(boolean useSingleBuffer) throws Exception {
     long maxClientLagSeconds = 1L;
     long schemaEvolutionDelayMs = 3 * 1000L; // must be enough for sdk to flush and commit
     long assertionSleepTimeMs = 6 * 1000L;
 
     conn = getConn(false);
-    Map<String, String> config = getConfig(false, true);
+    Map<String, String> config = getConfig(false, useSingleBuffer);
     config.put(ENABLE_SCHEMATIZATION_CONFIG, "true");
     config.put(
         SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD,
@@ -1610,6 +1611,7 @@ public class SnowflakeSinkServiceV2IT {
             .withSchemaEvolutionService(
                 new DelayedSchemaEvolutionService(conn, schemaEvolutionDelayMs))
             .build();
+    service.setRecordNumber(1);
     service.startPartition(table, new TopicPartition(topic, partition));
 
     service.insert(

--- a/src/test/java/com/snowflake/kafka/connector/records/SnowpipeStreamingMetaColumnTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/SnowpipeStreamingMetaColumnTest.java
@@ -53,6 +53,9 @@ class SnowpipeStreamingMetaColumnTest extends AbstractMetaColumnTest {
         new RecordService(
             fixedClock, new SnowflakeTableStreamingRecordMapper(mapper, false), mapper);
 
+    Map<String, String> config =
+            ImmutableMap.of(SNOWFLAKE_STREAMING_METADATA_CONNECTOR_PUSH_TIME, "true");
+    service.setMetadataConfig(new SnowflakeMetadataConfig(config));
     // when
     Map<String, Object> recordData = service.getProcessedRecordForStreamingIngest(record);
     JsonNode metadata = getMetadataNode(recordData);


### PR DESCRIPTION
This PR needs to be merged to the `3.0.x-nirut` before merging that here https://github.com/confluentinc/snowflake-kafka-connector/pull/110.

It brings proxy server and dns filtering related changes.