### PR TITLE
update snowflake jdbc 3.23.0-4 to increase jwt ttl

### DIFF
--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -482,7 +482,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.23.0-3</version>
+            <version>3.23.0-4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
We are seeing quite a few "Message: JWT token is invalid". Increasing the timeout to 5minutes to mitigate.

`snowflake-jdbc` version update here is released with https://github.com/confluentinc/snowflake-jdbc/pull/36 