### PR TITLE
CC-35563 Don't throw SnowflakeKafkaConnectorException from TopicToTableValidator

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -337,31 +337,6 @@ public class SnowflakeSinkConnectorConfig {
     }
   }
 
-  public static class TopicToTableValidator implements ConfigDef.Validator {
-    public TopicToTableValidator() {}
-
-    public void ensureValid(String name, Object value) {
-      String s = (String) value;
-      if (s != null && !s.isEmpty()) // this value is optional and can be empty
-      {
-        try {
-          if (Utils.parseTopicToTableMap(s) == null) {
-            throw new ConfigException(
-                name, value, "Format: <topic-1>:<table-1>,<topic-2>:<table-2>,...");
-          }
-        } catch (SnowflakeKafkaConnectorException e) {
-          throw new ConfigException(
-              name, value, "Format: <topic-1>:<table-1>,<topic-2>:<table-2>,...");
-        }
-      }
-    }
-
-    public String toString() {
-      return "Topic to table map format : comma-separated tuples, e.g."
-          + " <topic-1>:<table-1>,<topic-2>:<table-2>,... ";
-    }
-  }
-
   /* Validator to validate Kafka Provider values which says where kafka is hosted */
   public static class KafkaProviderValidator implements ConfigDef.Validator {
     public KafkaProviderValidator() {}

--- a/src/main/java/com/snowflake/kafka/connector/config/TopicToTableValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/TopicToTableValidator.java
@@ -1,6 +1,7 @@
 package com.snowflake.kafka.connector.config;
 
 import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
@@ -11,7 +12,12 @@ class TopicToTableValidator implements ConfigDef.Validator {
     String s = (String) value;
     if (s != null && !s.isEmpty()) // this value is optional and can be empty
     {
-      if (Utils.parseTopicToTableMap(s) == null) {
+      try {
+        if (Utils.parseTopicToTableMap(s) == null) {
+          throw new ConfigException(
+              name, value, "Format: <topic-1>:<table-1>,<topic-2>:<table-2>,...");
+        }
+      } catch (SnowflakeKafkaConnectorException e) {
         throw new ConfigException(
             name, value, "Format: <topic-1>:<table-1>,<topic-2>:<table-2>,...");
       }

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -407,4 +407,26 @@ public class ConnectorIT {
     Thread.sleep(6000);
     testThread.shutdownNow();
   }
+
+  @Test
+  public void testInvalidTopicToTableConfigValues() {
+    Map<String, String> config = getCorrectConfig();
+
+    String[] invalidValues = {
+            "topic1:table1,topic1:table2",  // duplicate topic
+            "topic1:!@#@!#!@",              // invalid table name
+            "topic1:a",                     // too short table name
+            "$@#$#@%^$12312"                // invalid format
+    };
+
+    for (String invalidValue : invalidValues) {
+      config.put(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP, invalidValue);
+      Map<String, ConfigValue> validateMap = toValidateMap(config);
+
+      assertPropHasError(
+              validateMap,
+              new String[] { SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP }
+      );
+    }
+  }
 }


### PR DESCRIPTION
Manual Tests -> https://confluentinc.atlassian.net/wiki/spaces/~712020d7bfb4a0cfcc48d2a32542edfd7193a0/pages/4690215049/CC-35563+Don+t+throw+SnowflakeKafkaConnectorException+from+TopicToTableValidator

Why are we catching that exception?
The exception (SnowflakeKafkaConnectorException) that is getting thrown by parseTopicToTableMap is a runtime exception. If not catched and re-raised as config exception it leads to 5xx failures on the connectors service end.

Why are we removing the validator in SnowflakeSinkConnectorConfig.java?
This validator is unused duplicate code that was overlooked during the v3 upgrade and should have been removed then.