### PR TITLE
CC-35770 Set timeouts for validation

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
@@ -85,7 +85,7 @@ public class SnowflakeConnectionServiceFactory {
 
       Properties proxyProperties = InternalUtils.generateProxyParametersIfRequired(conf);
       Properties connectionProperties =
-          InternalUtils.createProperties(conf, 0, 60, this.url, ingestionMethodConfig);
+          InternalUtils.createProperties(conf, this.networkTimeOut, this.loginTimeOut, this.url, ingestionMethodConfig);
       Properties jdbcPropertiesMap = InternalUtils.parseJdbcPropertiesMap(conf);
       this.jdbcProperties =
           JdbcProperties.create(connectionProperties, proxyProperties, jdbcPropertiesMap);


### PR DESCRIPTION
Currently the values were hardcoded to networkTimeout 0 and loginTimeout to 60
networkTimeout 0 means no network timeout is set. [ref](https://docs.snowflake.com/en/developer-guide/jdbc/jdbc-parameters#networktimeout)

Set the values appropriately to avoid validation timeout errors

We are trying to set it [here](https://github.com/confluentinc/snowflake-kafka-connector/blob/3.1.x/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java#L235-L240) but the setProperties method is not using those values but using [hardcoded value](https://github.com/confluentinc/snowflake-kafka-connector/blob/3.1.x/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java#L88)  