### PR TITLE
CC-36402 Add taskId and connectorName to streaming properties

### DIFF
--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -500,7 +500,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>3.0.1-8</version>
+            <version>3.0.1-9</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.snowflake</groupId>

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -152,7 +152,6 @@ public class SnowflakeSinkTask extends SinkTask {
   @Override
   public void start(final Map<String, String> parsedConfig) {
     this.DYNAMIC_LOGGER.info("starting task...");
-    this.DYNAMIC_LOGGER.info("Parsed config: {}", parsedConfig);
 
     // get task id and start time
     this.taskStartTime = System.currentTimeMillis();

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -152,6 +152,7 @@ public class SnowflakeSinkTask extends SinkTask {
   @Override
   public void start(final Map<String, String> parsedConfig) {
     this.DYNAMIC_LOGGER.info("starting task...");
+    this.DYNAMIC_LOGGER.info("Parsed config: {}", parsedConfig);
 
     // get task id and start time
     this.taskStartTime = System.currentTimeMillis();

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -71,6 +71,7 @@ public class Utils {
 
   // connector parameter list
   public static final String NAME = "name";
+  public static final String CONNECTOR_NAME = "connector_name";
   public static final String SF_DATABASE = "snowflake.database.name";
   public static final String SF_SCHEMA = "snowflake.schema.name";
   public static final String SF_USER = "snowflake.user.name";

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -228,7 +228,12 @@ public class StreamingUtils {
     connectorConfig.computeIfPresent(
         Utils.NAME,
         (key, value) -> {
-          streamingProperties.put(Utils.CONNECTOR_NAME, value);
+          String connectorName = value;
+          int lastUnderscore = connectorName.lastIndexOf('_');
+          if (lastUnderscore != -1) {
+            connectorName = connectorName.substring(0, lastUnderscore);
+          }
+          streamingProperties.put(Utils.CONNECTOR_NAME, connectorName);
           return value;
         });
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -228,10 +228,10 @@ public class StreamingUtils {
     connectorConfig.computeIfPresent(
         Utils.NAME,
         (key, value) -> {
-          String connectorName = value;
-          int lastUnderscore = connectorName.lastIndexOf('_');
-          if (lastUnderscore != -1) {
-            connectorName = connectorName.substring(0, lastUnderscore);
+          String connectorName = value.replace('_', '-');
+          int lastHyphen = connectorName.lastIndexOf('-');
+          if (lastHyphen != -1) {
+            connectorName = connectorName.substring(0, lastHyphen);
           }
           streamingProperties.put(Utils.CONNECTOR_NAME, connectorName);
           return value;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -219,6 +219,20 @@ public class StreamingUtils {
         });
 
     connectorConfig.computeIfPresent(
+        Utils.TASK_ID,
+        (key, value) -> {
+          streamingProperties.put(Utils.TASK_ID, value);
+          return value;
+        });
+
+    connectorConfig.computeIfPresent(
+        Utils.NAME,
+        (key, value) -> {
+          streamingProperties.put(Utils.CONNECTOR_NAME, value);
+          return value;
+        });
+
+    connectorConfig.computeIfPresent(
         SnowflakeSinkConnectorConfig.DISALLOW_CIDR_RANGES,
         (key, value) -> {
           streamingProperties.put(SnowflakeSinkConnectorConfig.DISALLOW_CIDR_RANGES, value);

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
@@ -346,6 +346,7 @@ public class StreamingClientPropertiesTest {
     config1.put(Utils.NAME, "dogConnector");
     config1.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, "1000000");
 
+    config2.put(Utils.NAME, "dogConnector");
     // get properties
     StreamingClientProperties prop1 = new StreamingClientProperties(config1);
     StreamingClientProperties prop2 = new StreamingClientProperties(config2);

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
@@ -363,4 +363,15 @@ public class StreamingClientPropertiesTest {
     assert !prop1.equals(prop2);
     assert prop1.hashCode() != prop2.hashCode();
   }
+
+  @Test
+  public void testStreamingClientPropertyConnectorName() {
+    Map<String, String> config1 = TestUtils.getConfForStreaming();
+    config1.put(Utils.NAME, "lcc1234_0_connector");
+    StreamingClientProperties prop1 = new StreamingClientProperties(config1);
+    assert "lcc1234-0".equals(prop1.clientProperties.getProperty(Utils.CONNECTOR_NAME));
+    config1.put(Utils.NAME, "catConnector");
+    prop1 = new StreamingClientProperties(config1);
+    assert "catConnector".equals(prop1.clientProperties.getProperty(Utils.CONNECTOR_NAME));
+  }
 }


### PR DESCRIPTION
Pass connectorName and taskID to streaming properties.

https://confluentinc.atlassian.net/wiki/spaces/~712020d7bfb4a0cfcc48d2a32542edfd7193a0/pages/4776896524/CC-36402+Named+ingest+threads