### PR TITLE
CC-37666: Expose OCSP Configs

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -129,6 +129,9 @@ public class SnowflakeSinkConnectorConfig {
   // JDBC properties map
   public static final String SNOWFLAKE_JDBC_MAP = "snowflake.jdbc.map";
 
+  // OCSP configuration to be injected to the JDBC properties map
+  public static final String SNOWFLAKE_DISABLE_OCSP_CHECKS = "snowflake.disable.ocsp.checks";
+
   // Snowflake Metadata Flags
   public static final String SNOWFLAKE_METADATA_CREATETIME = "snowflake.metadata.createtime";
   public static final String SNOWFLAKE_METADATA_TOPIC = "snowflake.metadata.topic";

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -392,12 +392,33 @@ public class InternalUtils {
 
   protected static Properties parseJdbcPropertiesMap(Map<String, String> conf) {
     String jdbcConfigMapInput = conf.get(SnowflakeSinkConnectorConfig.SNOWFLAKE_JDBC_MAP);
-    if (jdbcConfigMapInput == null) {
-      return new Properties();
-    }
-    Map<String, String> jdbcMap = Utils.parseCommaSeparatedKeyValuePairs(jdbcConfigMapInput);
     Properties properties = new Properties();
-    properties.putAll(jdbcMap);
+    
+    // Parse user-provided jdbc map if present
+    if (jdbcConfigMapInput != null) {
+      Map<String, String> jdbcMap = Utils.parseCommaSeparatedKeyValuePairs(jdbcConfigMapInput);
+      properties.putAll(jdbcMap);
+    }
+
+    String disableOCSPChecks = conf.get(SnowflakeSinkConnectorConfig.SNOWFLAKE_DISABLE_OCSP_CHECKS);
+    if (Boolean.parseBoolean(disableOCSPChecks)) {
+      String disableOCSPChecksKey = "disableOCSPChecks";
+      // If user already set this in jdbc.map, log a warning and override with explicit config
+      boolean keyAlreadyExists = properties.containsKey(disableOCSPChecksKey);
+      if (keyAlreadyExists) {
+        LOGGER.warn(
+            "Property {} is set in both {} and {}. "
+                + "The explicit config {} will override the value from {}.",
+            disableOCSPChecksKey,
+            SnowflakeSinkConnectorConfig.SNOWFLAKE_DISABLE_OCSP_CHECKS,
+            SnowflakeSinkConnectorConfig.SNOWFLAKE_JDBC_MAP,
+            SnowflakeSinkConnectorConfig.SNOWFLAKE_DISABLE_OCSP_CHECKS,
+            SnowflakeSinkConnectorConfig.SNOWFLAKE_JDBC_MAP);
+      }
+      // override with explicit config value
+      properties.put(disableOCSPChecksKey, Boolean.TRUE.toString());
+    }
+    
     return properties;
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
@@ -150,4 +150,64 @@ public class InternalUtilsTest {
     // then
     assertEquals(jdbcPropertiesMap.size(), 5);
   }
+
+  @Test
+  public void parseJdbcPropertiesMapWithOCSPPropertiesTest() {
+    String key = "snowflake.jdbc.map";
+    String input = "ocspFailOpen:true, disableOCSPChecks:false, ocspResponseCacheSize:1000";
+    Map<String, String> config = new HashMap<>();
+    config.put(key, input);
+    Properties jdbcPropertiesMap = InternalUtils.parseJdbcPropertiesMap(config);
+    assertEquals(jdbcPropertiesMap.size(), 3);
+    assertEquals("true", jdbcPropertiesMap.getProperty("ocspFailOpen"));
+    assertEquals("false", jdbcPropertiesMap.getProperty("disableOCSPChecks"));
+    assertEquals("1000", jdbcPropertiesMap.getProperty("ocspResponseCacheSize"));
+  }
+
+  @Test
+  public void parseJdbcPropertiesMapWithDisableOCSPChecksConfigTest() {
+    Map<String, String> config = new HashMap<>();
+    config.put(
+        com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_DISABLE_OCSP_CHECKS,
+        "true");
+    Properties jdbcPropertiesMap = InternalUtils.parseJdbcPropertiesMap(config);
+    assertEquals("true", jdbcPropertiesMap.getProperty("disableOCSPChecks"));
+  }
+
+  @Test
+  public void parseJdbcPropertiesMapWithDisableOCSPChecksConfigFalseTest() {
+    Map<String, String> config = new HashMap<>();
+    config.put(
+        com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_DISABLE_OCSP_CHECKS,
+        "false");
+    Properties jdbcPropertiesMap = InternalUtils.parseJdbcPropertiesMap(config);
+    assertEquals(0, jdbcPropertiesMap.size());
+    assertEquals(null, jdbcPropertiesMap.getProperty("disableOCSPChecks"));
+  }
+
+  @Test
+  public void parseJdbcPropertiesMapWithOCSPConflictTest() {
+    // explicit config should override jdbc.map when both are set
+    String key = "snowflake.jdbc.map";
+    String input = "disableOCSPChecks:false";
+    Map<String, String> config = new HashMap<>();
+    config.put(key, input);
+    config.put(
+        com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_DISABLE_OCSP_CHECKS,
+        "true");
+    Properties jdbcPropertiesMap = InternalUtils.parseJdbcPropertiesMap(config);
+    assertEquals("true", jdbcPropertiesMap.getProperty("disableOCSPChecks"));
+  }
+
+  @Test
+  public void parseJdbcPropertiesMapWithOCSPInJdbcMapOnlyTest() {
+    String key = "snowflake.jdbc.map";
+    String input = "disableOCSPChecks:true, ocspFailOpen:false";
+    Map<String, String> config = new HashMap<>();
+    config.put(key, input);
+    Properties jdbcPropertiesMap = InternalUtils.parseJdbcPropertiesMap(config);
+    assertEquals(2, jdbcPropertiesMap.size());
+    assertEquals("true", jdbcPropertiesMap.getProperty("disableOCSPChecks"));
+    assertEquals("false", jdbcPropertiesMap.getProperty("ocspFailOpen"));
+  }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
@@ -189,25 +189,15 @@ public class InternalUtilsTest {
   public void parseJdbcPropertiesMapWithOCSPConflictTest() {
     // explicit config should override jdbc.map when both are set
     String key = "snowflake.jdbc.map";
-    String input = "disableOCSPChecks:false";
+    String input = "disableOCSPChecks:false, ocspFailOpen:true";
     Map<String, String> config = new HashMap<>();
     config.put(key, input);
     config.put(
         com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_DISABLE_OCSP_CHECKS,
         "true");
     Properties jdbcPropertiesMap = InternalUtils.parseJdbcPropertiesMap(config);
+    // explicit config overrides disableOCSPChecks, but ocspFailOpen from jdbc.map is preserved
     assertEquals("true", jdbcPropertiesMap.getProperty("disableOCSPChecks"));
-  }
-
-  @Test
-  public void parseJdbcPropertiesMapWithOCSPInJdbcMapOnlyTest() {
-    String key = "snowflake.jdbc.map";
-    String input = "disableOCSPChecks:true, ocspFailOpen:false";
-    Map<String, String> config = new HashMap<>();
-    config.put(key, input);
-    Properties jdbcPropertiesMap = InternalUtils.parseJdbcPropertiesMap(config);
-    assertEquals(2, jdbcPropertiesMap.size());
-    assertEquals("true", jdbcPropertiesMap.getProperty("disableOCSPChecks"));
-    assertEquals("false", jdbcPropertiesMap.getProperty("ocspFailOpen"));
+    assertEquals("true", jdbcPropertiesMap.getProperty("ocspFailOpen"));
   }
 }


### PR DESCRIPTION
# Overview 

Adds a dedicated boolean configuration that allows users to disable OCSP certificate revocation checks without exposing the entire `snowflake.jdbc.map` configuration. Logs warning if both explicit config and `snowflake.jdbc.map` set the property (explicit config overrides), but the explicit config is preferred and overrides the one coming from`snowflake.jdbc.map`, if that is also provided.

# Testing

Tested on CP