### PR TITLE
Set enable.task.to.topic.partitions.validation default to false

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -296,7 +296,7 @@ public class SnowflakeSinkConnectorConfig {
 
   public static final String ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION =
       "enable.task.to.topic.partitions.validation";
-  public static final Boolean ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION_DEFAULT = true;
+  public static final Boolean ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION_DEFAULT = false;
   public static final String TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS =
       "task.to.topic.partitions.validation.interval.ms";
   public static final long TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS_DEFAULT =


### PR DESCRIPTION
Created a connector violating task to topic partition in old image.
<img width="1084" height="464" alt="Screenshot 2026-01-30 at 1 36 52 AM" src="https://github.com/user-attachments/assets/42a2361d-43c5-4fb7-ada4-2b6c825814be" />

Upgraded the image to have task to topic partition validation running, but it wont run as the default value set in code is False and since the connector is in config error state it wont apply the true value coming from cloud template.
<img width="743" height="530" alt="Screenshot 2026-01-30 at 1 52 45 AM" src="https://github.com/user-attachments/assets/2c165789-fb44-4172-811e-ec3f29b5f703" />

Task keeps on running without it getting failed, increased the task count from 2 to 4.
<img width="528" height="83" alt="Screenshot 2026-01-30 at 1 54 38 AM" src="https://github.com/user-attachments/assets/42d830ee-9fc7-4288-8df2-3aae8b9b3f20" />

enable.task.to.topic.partitions thread started
<img width="1723" height="565" alt="Screenshot 2026-01-30 at 1 54 56 AM" src="https://github.com/user-attachments/assets/69cea8cb-1e18-405f-abd7-98112aeaa536" />
