### PR TITLE
CC-38859, CC-38860 Enable dynamic flush and introduce task buffer limit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,11 +339,15 @@
 
         <!-- Ingest SDK for copy staged file into snowflake table -->
         <dependency>
-            <groupId>io.confluent</groupId>
+            <groupId>net.snowflake</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
             <version>3.0.1</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/lib/snowflake-ingest-sdk.jar</systemPath>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.snowflake</groupId>
+                    <artifactId>snowflake-jdbc</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -339,15 +339,11 @@
 
         <!-- Ingest SDK for copy staged file into snowflake table -->
         <dependency>
-            <groupId>net.snowflake</groupId>
+            <groupId>io.confluent</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
             <version>3.0.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>net.snowflake</groupId>
-                    <artifactId>snowflake-jdbc</artifactId>
-                </exclusion>
-            </exclusions>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/snowflake-ingest-sdk.jar</systemPath>
         </dependency>
 
         <dependency>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -497,24 +497,16 @@
         </dependency>
 
         <!-- Ingest SDK for copy staged file into snowflake table -->
-<!--        <dependency>-->
-<!--            <groupId>io.confluent</groupId>-->
-<!--            <artifactId>snowflake-ingest-sdk</artifactId>-->
-<!--            <version>3.0.1-9</version>-->
-<!--            <exclusions>-->
-<!--                <exclusion>-->
-<!--                    <groupId>net.snowflake</groupId>-->
-<!--                    <artifactId>snowflake-jdbc</artifactId>-->
-<!--                </exclusion>-->
-<!--            </exclusions>-->
-<!--        </dependency>-->
-
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>3.0.1</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/lib/snowflake-ingest-sdk.jar</systemPath>
+            <version>3.0.1-9</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.snowflake</groupId>
+                    <artifactId>snowflake-jdbc</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -497,16 +497,24 @@
         </dependency>
 
         <!-- Ingest SDK for copy staged file into snowflake table -->
+<!--        <dependency>-->
+<!--            <groupId>io.confluent</groupId>-->
+<!--            <artifactId>snowflake-ingest-sdk</artifactId>-->
+<!--            <version>3.0.1-9</version>-->
+<!--            <exclusions>-->
+<!--                <exclusion>-->
+<!--                    <groupId>net.snowflake</groupId>-->
+<!--                    <artifactId>snowflake-jdbc</artifactId>-->
+<!--                </exclusion>-->
+<!--            </exclusions>-->
+<!--        </dependency>-->
+
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>3.0.1-9</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>net.snowflake</groupId>
-                    <artifactId>snowflake-jdbc</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>3.0.1</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/snowflake-ingest-sdk.jar</systemPath>
         </dependency>
 
         <dependency>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -500,7 +500,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>3.0.1-9</version>
+            <version>3.0.1-10</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.snowflake</groupId>

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -309,6 +309,12 @@ public class SnowflakeSinkConnectorConfig {
       "task.to.topic.partitions.validation.memory.limit.bytes";
   public static final long TASK_TO_TOPIC_PARTITIONS_VALIDATION_MEMORY_LIMIT_IN_BYTES_DEFAULT =
       524288000; // 500MB
+  public static final String ENABLE_DYNAMIC_FLUSH = "enable.dynamic.flush";
+  public static final Boolean ENABLE_DYNAMIC_FLUSH_DEFAULT = false;
+  // todo can task.to.topic.partitions.memory.limit.bytes be used instead of
+  // task.buffer.total.limit.bytes
+  public static final String TASK_BUFFER_TOTAL_LIMIT_BYTES = "task.buffer.total.limit.bytes";
+  public static final long TASK_BUFFER_TOTAL_LIMIT_BYTES_DEFAULT = 524288000; // 500MB
 
   public static void setDefaultValues(Map<String, String> config) {
     setFieldToDefaultValues(config, BUFFER_COUNT_RECORDS, BUFFER_COUNT_RECORDS_DEFAULT, "");

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -311,8 +311,6 @@ public class SnowflakeSinkConnectorConfig {
       524288000; // 500MB
   public static final String ENABLE_DYNAMIC_FLUSH = "enable.dynamic.flush";
   public static final Boolean ENABLE_DYNAMIC_FLUSH_DEFAULT = false;
-  // todo can task.to.topic.partitions.memory.limit.bytes be used instead of
-  // task.buffer.total.limit.bytes
   public static final String TASK_BUFFER_TOTAL_LIMIT_BYTES = "task.buffer.total.limit.bytes";
   public static final long TASK_BUFFER_TOTAL_LIMIT_BYTES_DEFAULT = 524288000; // 500MB
 

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -308,11 +308,11 @@ public class SnowflakeSinkConnectorConfig {
   public static final String TASK_TO_TOPIC_PARTITIONS_VALIDATION_MEMORY_LIMIT_IN_BYTES =
       "task.to.topic.partitions.validation.memory.limit.bytes";
   public static final long TASK_TO_TOPIC_PARTITIONS_VALIDATION_MEMORY_LIMIT_IN_BYTES_DEFAULT =
-      524288000; // 500MB
+      500000000;
   public static final String ENABLE_DYNAMIC_FLUSH = "enable.dynamic.flush";
   public static final Boolean ENABLE_DYNAMIC_FLUSH_DEFAULT = false;
   public static final String TASK_BUFFER_TOTAL_LIMIT_BYTES = "task.buffer.total.limit.bytes";
-  public static final long TASK_BUFFER_TOTAL_LIMIT_BYTES_DEFAULT = 524288000; // 500MB
+  public static final long TASK_BUFFER_TOTAL_LIMIT_BYTES_DEFAULT = 500000000;
 
   public static void setDefaultValues(Map<String, String> config) {
     setFieldToDefaultValues(config, BUFFER_COUNT_RECORDS, BUFFER_COUNT_RECORDS_DEFAULT, "");

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -646,6 +646,18 @@ public class ConnectorConfigDefinition {
             ConfigDef.Importance.LOW,
             "Action to take when task to topic partitions validation fails. "
                 + "Allowed values are: 'fail' (throw exception and fail the task) or "
-                + "'warn' (log a warning message only).");
+                + "'warn' (log a warning message only).")
+        .define(
+            ENABLE_DYNAMIC_FLUSH,
+            ConfigDef.Type.BOOLEAN,
+            ENABLE_DYNAMIC_FLUSH_DEFAULT,
+            ConfigDef.Importance.LOW,
+            "Enable dynamic flush to optimize task to topic partition usage.")
+        .define(
+            TASK_BUFFER_TOTAL_LIMIT_BYTES,
+            ConfigDef.Type.LONG,
+            TASK_BUFFER_TOTAL_LIMIT_BYTES_DEFAULT,
+            ConfigDef.Importance.LOW,
+            "Maximum total buffer size in bytes per task.");
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
@@ -99,22 +99,19 @@ public class SnowflakeSinkServiceFactory {
         svc.configureDisableReprocessFilesCleanup(disableReprocessFilesCleanup);
 
         if (connectorConfig != null
-            && connectorConfig.containsKey(
-            SnowflakeSinkConnectorConfig.ENABLE_DYNAMIC_FLUSH)) {
+            && connectorConfig.containsKey(SnowflakeSinkConnectorConfig.ENABLE_DYNAMIC_FLUSH)) {
           boolean enableDynamicFlush =
               Boolean.parseBoolean(
-                  connectorConfig.get(
-                      SnowflakeSinkConnectorConfig.ENABLE_DYNAMIC_FLUSH));
+                  connectorConfig.get(SnowflakeSinkConnectorConfig.ENABLE_DYNAMIC_FLUSH));
           svc.configureEnableDynamicFlush(enableDynamicFlush);
         }
 
         if (connectorConfig != null
             && connectorConfig.containsKey(
-            SnowflakeSinkConnectorConfig.TASK_BUFFER_TOTAL_LIMIT_BYTES)) {
+                SnowflakeSinkConnectorConfig.TASK_BUFFER_TOTAL_LIMIT_BYTES)) {
           long taskBufferLimitBytes =
               Long.parseLong(
-                  connectorConfig.get(
-                      SnowflakeSinkConnectorConfig.TASK_BUFFER_TOTAL_LIMIT_BYTES));
+                  connectorConfig.get(SnowflakeSinkConnectorConfig.TASK_BUFFER_TOTAL_LIMIT_BYTES));
           svc.configureTaskBufferLimitBytes(taskBufferLimitBytes);
         }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
@@ -97,6 +97,27 @@ public class SnowflakeSinkServiceFactory {
                       SnowflakeSinkConnectorConfig.SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP));
         }
         svc.configureDisableReprocessFilesCleanup(disableReprocessFilesCleanup);
+
+        if (connectorConfig != null
+            && connectorConfig.containsKey(
+            SnowflakeSinkConnectorConfig.ENABLE_DYNAMIC_FLUSH)) {
+          boolean enableDynamicFlush =
+              Boolean.parseBoolean(
+                  connectorConfig.get(
+                      SnowflakeSinkConnectorConfig.ENABLE_DYNAMIC_FLUSH));
+          svc.configureEnableDynamicFlush(enableDynamicFlush);
+        }
+
+        if (connectorConfig != null
+            && connectorConfig.containsKey(
+            SnowflakeSinkConnectorConfig.TASK_BUFFER_TOTAL_LIMIT_BYTES)) {
+          long taskBufferLimitBytes =
+              Long.parseLong(
+                  connectorConfig.get(
+                      SnowflakeSinkConnectorConfig.TASK_BUFFER_TOTAL_LIMIT_BYTES));
+          svc.configureTaskBufferLimitBytes(taskBufferLimitBytes);
+        }
+
       } else {
         this.service = new SnowflakeSinkServiceV2(conn, connectorConfig);
       }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -1,7 +1,7 @@
 package com.snowflake.kafka.connector.internal;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_DYNAMIC_FLUSH_DEFAULT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_BUFFER_TOTAL_LIMIT_BYTES_DEFAULT;
 import static com.snowflake.kafka.connector.Utils.createNamedThreadFactory;
 import static com.snowflake.kafka.connector.internal.FileNameUtils.searchForMissingOffsets;
@@ -484,27 +484,30 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
   }
 
   /**
-   * Check total buffer across all pipes and flush largest ones
-   * until total is under the configured limit.
+   * Check total buffer across all pipes and flush largest ones until total is under the configured
+   * limit.
    */
   private void enforceTaskBufferLimit() {
     // Calculate total buffer size first
-    long totalBufferSize = pipes.values().stream()
-        .mapToLong(pipe -> pipe.buffer.getBufferSizeBytes())
-        .sum();
+    long totalBufferSize =
+        pipes.values().stream().mapToLong(pipe -> pipe.buffer.getBufferSizeBytes()).sum();
 
     if (totalBufferSize <= taskBufferLimitBytes) {
       return; // Under limit, nothing to do
     }
 
-    LOGGER.info("Total buffer size {} bytes across pipes exceeds limit {} bytes, initiating flush",
-        totalBufferSize, taskBufferLimitBytes);
+    LOGGER.info(
+        "Total buffer size {} bytes across pipes exceeds limit {} bytes, initiating flush",
+        totalBufferSize,
+        taskBufferLimitBytes);
 
     // Sort pipes by buffer size (descending) - largest first
-    List<ServiceContext> sortedPipes = pipes.values().stream()
-        .sorted(Comparator.comparingLong(
-            (ServiceContext pipe) -> pipe.buffer.getBufferSizeBytes()).reversed())
-        .collect(Collectors.toList());
+    List<ServiceContext> sortedPipes =
+        pipes.values().stream()
+            .sorted(
+                Comparator.comparingLong((ServiceContext pipe) -> pipe.buffer.getBufferSizeBytes())
+                    .reversed())
+            .collect(Collectors.toList());
 
     int flushedCount = 0;
     long originalSize = totalBufferSize;
@@ -522,8 +525,11 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
       }
     }
 
-    LOGGER.info("Flushed {} pipes, reduced buffer from {} to {} bytes",
-        flushedCount, originalSize, totalBufferSize);
+    LOGGER.info(
+        "Flushed {} pipes, reduced buffer from {} to {} bytes",
+        flushedCount,
+        originalSize,
+        totalBufferSize);
   }
 
   private class ServiceContext {
@@ -1294,6 +1300,7 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
 
     /**
      * Get the current buffer size in bytes for this pipe.
+     *
      * @return buffer size in bytes
      */
     public long getBufferSizeBytes() {

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -1,6 +1,8 @@
 package com.snowflake.kafka.connector.internal;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_DYNAMIC_FLUSH_DEFAULT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_BUFFER_TOTAL_LIMIT_BYTES_DEFAULT;
 import static com.snowflake.kafka.connector.Utils.createNamedThreadFactory;
 import static com.snowflake.kafka.connector.internal.FileNameUtils.searchForMissingOffsets;
 import static com.snowflake.kafka.connector.internal.metrics.MetricsUtil.BUFFER_RECORD_COUNT;
@@ -30,6 +32,7 @@ import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -102,6 +105,9 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
 
   // CC-30278 if enabled cleaner won't delete reprocess files on stage
   private boolean disableReprocessFilesCleanup = false;
+
+  private boolean enableDynamicFlush = ENABLE_DYNAMIC_FLUSH_DEFAULT;
+  private long taskBufferLimitBytes = TASK_BUFFER_TOTAL_LIMIT_BYTES_DEFAULT;
 
   private final Set<String> perTableWarningNotifications = new HashSet<>();
   private final String V1CleanerThreadType = "v1-cleaner";
@@ -214,6 +220,10 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
       if (pipe.shouldFlush()) {
         pipe.flushBuffer();
       }
+    }
+    if (enableDynamicFlush) {
+      // check total buffer size across all pipes and flush if exceeds task buffer limit
+      enforceTaskBufferLimit();
     }
   }
 
@@ -463,6 +473,57 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
 
   public void configureDisableReprocessFilesCleanup(boolean disable) {
     disableReprocessFilesCleanup = disable;
+  }
+
+  public void configureEnableDynamicFlush(boolean enable) {
+    enableDynamicFlush = enable;
+  }
+
+  public void configureTaskBufferLimitBytes(long taskBufferLimitBytes) {
+    this.taskBufferLimitBytes = taskBufferLimitBytes;
+  }
+
+  /**
+   * Check total buffer across all pipes and flush largest ones
+   * until total is under the configured limit.
+   */
+  private void enforceTaskBufferLimit() {
+    // Calculate total buffer size first
+    long totalBufferSize = pipes.values().stream()
+        .mapToLong(pipe -> pipe.buffer.getBufferSizeBytes())
+        .sum();
+
+    if (totalBufferSize <= taskBufferLimitBytes) {
+      return; // Under limit, nothing to do
+    }
+
+    LOGGER.info("Total buffer size {} bytes across pipes exceeds limit {} bytes, initiating flush",
+        totalBufferSize, taskBufferLimitBytes);
+
+    // Sort pipes by buffer size (descending) - largest first
+    List<ServiceContext> sortedPipes = pipes.values().stream()
+        .sorted(Comparator.comparingLong(
+            (ServiceContext pipe) -> pipe.buffer.getBufferSizeBytes()).reversed())
+        .collect(Collectors.toList());
+
+    int flushedCount = 0;
+    long originalSize = totalBufferSize;
+
+    for (ServiceContext pipe : sortedPipes) {
+      if (totalBufferSize <= taskBufferLimitBytes) {
+        break;
+      }
+
+      long pipeBufferSize = pipe.buffer.getBufferSizeBytes();
+      if (pipeBufferSize > 0) {
+        pipe.flushBuffer();
+        totalBufferSize -= pipeBufferSize;
+        flushedCount++;
+      }
+    }
+
+    LOGGER.info("Flushed {} pipes, reduced buffer from {} to {} bytes",
+        flushedCount, originalSize, totalBufferSize);
   }
 
   private class ServiceContext {
@@ -1229,6 +1290,14 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
       if (enableCustomJMXMonitoring) {
         metricsJmxReporter.removeMetricsFromRegistry(this.pipeName);
       }
+    }
+
+    /**
+     * Get the current buffer size in bytes for this pipe.
+     * @return buffer size in bytes
+     */
+    public long getBufferSizeBytes() {
+      return buffer.getBufferSizeBytes();
     }
 
     /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
@@ -1,5 +1,7 @@
 package com.snowflake.kafka.connector.internal;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_DYNAMIC_FLUSH;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_DYNAMIC_FLUSH_DEFAULT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION_DEFAULT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS;
@@ -39,8 +41,10 @@ public class TaskToTopicPartitionValidator extends Thread {
   private final CountDownLatch shutdownLatch;
   private final long validationIntervalMs;
   private final long memoryLimitBytes;
+  private final boolean enableDynamicFlush;
   private final TaskToTopicPartitionValidatorFailureAction failureAction;
   private AdminClient adminClient;
+  private final int RELAXED_MULTIPLIER = 2;
 
   public TaskToTopicPartitionValidator(
       Map<String, String> config, AtomicReference<Throwable> failure, String taskConfigId) {
@@ -60,11 +64,19 @@ public class TaskToTopicPartitionValidator extends Thread {
             config.getOrDefault(
                 TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS,
                 String.valueOf(TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS_DEFAULT)));
-    this.memoryLimitBytes =
+    long baseMemoryLimitBytes =
         Long.parseLong(
             config.getOrDefault(
                 TASK_TO_TOPIC_PARTITIONS_VALIDATION_MEMORY_LIMIT_IN_BYTES,
                 String.valueOf(TASK_TO_TOPIC_PARTITIONS_VALIDATION_MEMORY_LIMIT_IN_BYTES_DEFAULT)));
+    // If dynamic flush is enabled, we allow up to 2x topic partitions before triggering
+    // validation failure, since dynamic flush can help keeping memory usage under control.
+    this.enableDynamicFlush =
+        Boolean.parseBoolean(
+            config.getOrDefault(
+                ENABLE_DYNAMIC_FLUSH, String.valueOf(ENABLE_DYNAMIC_FLUSH_DEFAULT)));
+    this.memoryLimitBytes =
+        enableDynamicFlush ? baseMemoryLimitBytes * RELAXED_MULTIPLIER : baseMemoryLimitBytes;
     String failureActionStr =
         config.getOrDefault(
             TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION,
@@ -241,12 +253,32 @@ public class TaskToTopicPartitionValidator extends Thread {
     if (totalMemoryUsage > this.memoryLimitBytes) {
       long requiredTasks =
           (totalPartitions * bufferSizeBytes + this.memoryLimitBytes - 1) / this.memoryLimitBytes;
-      String errorMessage =
-          String.format(
-              "Total memory usage per task (%d bytes) exceeds limit (%d bytes). "
-                  + "Please increase the tasks.max to at least %d.",
-              totalMemoryUsage, this.memoryLimitBytes, requiredTasks);
-
+      String errorMessage;
+      if (this.enableDynamicFlush) {
+        // Dynamic flush already enabled, just suggest increasing tasks
+        errorMessage =
+            String.format(
+                "Total memory usage per task (%d bytes) exceeds limit (%d bytes). "
+                    + "Please increase the tasks.max to at least %d.",
+                totalMemoryUsage, this.memoryLimitBytes, requiredTasks);
+      } else {
+        // Dynamic flush not enabled, suggest both options
+        long memoryLimitWithDynamicFlush = this.memoryLimitBytes * RELAXED_MULTIPLIER;
+        long requiredTasksWithDynamicFlush =
+            (totalPartitions * bufferSizeBytes + memoryLimitWithDynamicFlush - 1)
+                / memoryLimitWithDynamicFlush;
+        errorMessage =
+            String.format(
+                "Total memory usage per task (%d bytes) exceeds limit (%d bytes). "
+                    + "Please increase the tasks.max to at least %d, "
+                    + "or reach out to Confluent to enable %s and ensure the "
+                    + "tasks.max is at least %d.",
+                totalMemoryUsage,
+                this.memoryLimitBytes,
+                requiredTasks,
+                ENABLE_DYNAMIC_FLUSH,
+                requiredTasksWithDynamicFlush);
+      }
       if (this.failureAction == TaskToTopicPartitionValidatorFailureAction.FAIL) {
         LOGGER.error(errorMessage);
         // This will be caught by the run() loop and call fail()
@@ -296,8 +328,9 @@ public class TaskToTopicPartitionValidator extends Thread {
   }
 
   /**
-   * Fail the connector with an unrecoverable error and stop the validator thread
-   * if the failure action is set to FAIL. Otherwise, just log the error.
+   * Fail the connector with an unrecoverable error and stop the validator thread if the failure
+   * action is set to FAIL. Otherwise, just log the error.
+   *
    * @param t the cause of the failure
    * @param message additional message to log with the error
    */

--- a/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
@@ -272,7 +272,7 @@ public class TaskToTopicPartitionValidator extends Thread {
         errorMessage =
             String.format(
                 "Partitions per task (%d) exceeds maximum allowed partitions (%d). Please increase"
-                    + " the tasks.max to at least %d, or reach out to Confluent to enable %s which"
+                    + " the tasks.max to at least %d, or enable %s which"
                     + " would allow %d partitions per task and ensure the tasks.max is at least"
                     + " %d.",
                 partitionsPerTask,

--- a/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
@@ -1,5 +1,7 @@
 package com.snowflake.kafka.connector.internal;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_DEFAULT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_DYNAMIC_FLUSH;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_DYNAMIC_FLUSH_DEFAULT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION;
@@ -40,7 +42,7 @@ public class TaskToTopicPartitionValidator extends Thread {
   private final AtomicReference<Throwable> failure;
   private final CountDownLatch shutdownLatch;
   private final long validationIntervalMs;
-  private final long memoryLimitBytes;
+  private final int maxTopicPartitionsPerTask;
   private final boolean enableDynamicFlush;
   private final TaskToTopicPartitionValidatorFailureAction failureAction;
   private AdminClient adminClient;
@@ -69,14 +71,19 @@ public class TaskToTopicPartitionValidator extends Thread {
             config.getOrDefault(
                 TASK_TO_TOPIC_PARTITIONS_VALIDATION_MEMORY_LIMIT_IN_BYTES,
                 String.valueOf(TASK_TO_TOPIC_PARTITIONS_VALIDATION_MEMORY_LIMIT_IN_BYTES_DEFAULT)));
-    // If dynamic flush is enabled, we allow up to 2x topic partitions before triggering
-    // validation failure, since dynamic flush can help keeping memory usage under control.
+    long bufferSizeBytes =
+        Long.parseLong(
+            config.getOrDefault(BUFFER_SIZE_BYTES, String.valueOf(BUFFER_SIZE_BYTES_DEFAULT)));
+    int baseMaxTopicPartitionsPerTask = (int) (baseMemoryLimitBytes / bufferSizeBytes);
     this.enableDynamicFlush =
         Boolean.parseBoolean(
             config.getOrDefault(
                 ENABLE_DYNAMIC_FLUSH, String.valueOf(ENABLE_DYNAMIC_FLUSH_DEFAULT)));
-    this.memoryLimitBytes =
-        enableDynamicFlush ? baseMemoryLimitBytes * RELAXED_MULTIPLIER : baseMemoryLimitBytes;
+    // If dynamic flush is enabled, we allow up to 2x topic partitions
+    this.maxTopicPartitionsPerTask =
+        enableDynamicFlush
+            ? baseMaxTopicPartitionsPerTask * RELAXED_MULTIPLIER
+            : baseMaxTopicPartitionsPerTask;
     String failureActionStr =
         config.getOrDefault(
             TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION,
@@ -201,21 +208,10 @@ public class TaskToTopicPartitionValidator extends Thread {
 
   @VisibleForTesting
   void validateTaskToTopicPartitions() {
-    LOGGER.debug("Validating buffer size configuration...");
+    LOGGER.debug("Validating task to topic partitions configuration...");
 
     // Get topics from config
     List<String> topics = getTopicsFromConfig();
-
-    // Get buffer size from config
-    long bufferSizeBytes = SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_DEFAULT;
-    String bufferSizeStr = config.get(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
-    if (bufferSizeStr != null) {
-      try {
-        bufferSizeBytes = Long.parseLong(bufferSizeStr);
-      } catch (NumberFormatException e) {
-        LOGGER.warn("Invalid buffer.size.bytes value: {}, using default", bufferSizeStr);
-      }
-    }
 
     // Get tasks.max from config
     int maxTasks = 1;
@@ -240,43 +236,50 @@ public class TaskToTopicPartitionValidator extends Thread {
       totalPartitions += desc.partitions().size();
     }
 
-    // Calculate average memory usage, assumes even partition distribution across tasks
-    long totalMemoryUsage = (totalPartitions * bufferSizeBytes) / maxTasks;
+    // Calculate partitions per task, assumes even partition distribution across tasks
+    int partitionsPerTask = (totalPartitions + maxTasks - 1) / maxTasks; // Ceiling division
     LOGGER.info(
-        "Total partitions: {}, Buffer size: {}, Max Tasks: {}, Estimated average memory usage per"
-            + " task: {} bytes",
+        "Total partitions: {}, Max Tasks: {}, Partitions per task: {}, Max allowed partitions per"
+            + " task: {}",
         totalPartitions,
-        bufferSizeBytes,
         maxTasks,
-        totalMemoryUsage);
+        partitionsPerTask,
+        this.maxTopicPartitionsPerTask);
 
-    if (totalMemoryUsage > this.memoryLimitBytes) {
-      long requiredTasks =
-          (totalPartitions * bufferSizeBytes + this.memoryLimitBytes - 1) / this.memoryLimitBytes;
+    if (partitionsPerTask > this.maxTopicPartitionsPerTask) {
+      // Calculate minimum required tasks
+      int requiredTasks =
+          (totalPartitions + this.maxTopicPartitionsPerTask - 1) / this.maxTopicPartitionsPerTask;
       String errorMessage;
       if (this.enableDynamicFlush) {
         // Dynamic flush already enabled, just suggest increasing tasks
         errorMessage =
             String.format(
-                "Total memory usage per task (%d bytes) exceeds limit (%d bytes). "
-                    + "Please increase the tasks.max to at least %d.",
-                totalMemoryUsage, this.memoryLimitBytes, requiredTasks);
+                "Partitions per task (%d) exceeds maximum allowed partitions (%d). Please increase"
+                    + " the tasks.max to at least %d to ensure each task handles at most %d"
+                    + " partitions.",
+                partitionsPerTask,
+                this.maxTopicPartitionsPerTask,
+                requiredTasks,
+                this.maxTopicPartitionsPerTask);
       } else {
         // Dynamic flush not enabled, suggest both options
-        long memoryLimitWithDynamicFlush = this.memoryLimitBytes * RELAXED_MULTIPLIER;
-        long requiredTasksWithDynamicFlush =
-            (totalPartitions * bufferSizeBytes + memoryLimitWithDynamicFlush - 1)
-                / memoryLimitWithDynamicFlush;
+        int maxTopicPartitionsWithDynamicFlush =
+            this.maxTopicPartitionsPerTask * RELAXED_MULTIPLIER;
+        int requiredTasksWithDynamicFlush =
+            (totalPartitions + maxTopicPartitionsWithDynamicFlush - 1)
+                / maxTopicPartitionsWithDynamicFlush;
         errorMessage =
             String.format(
-                "Total memory usage per task (%d bytes) exceeds limit (%d bytes). "
-                    + "Please increase the tasks.max to at least %d, "
-                    + "or reach out to Confluent to enable %s and ensure the "
-                    + "tasks.max is at least %d.",
-                totalMemoryUsage,
-                this.memoryLimitBytes,
+                "Partitions per task (%d) exceeds maximum allowed partitions (%d). Please increase"
+                    + " the tasks.max to at least %d, or reach out to Confluent to enable %s which"
+                    + " would allow %d partitions per task and ensure the tasks.max is at least"
+                    + " %d.",
+                partitionsPerTask,
+                this.maxTopicPartitionsPerTask,
                 requiredTasks,
                 ENABLE_DYNAMIC_FLUSH,
+                maxTopicPartitionsWithDynamicFlush,
                 requiredTasksWithDynamicFlush);
       }
       if (this.failureAction == TaskToTopicPartitionValidatorFailureAction.FAIL) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DefaultStreamingConfigValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DefaultStreamingConfigValidator.java
@@ -100,6 +100,10 @@ public class DefaultStreamingConfigValidator implements StreamingConfigValidator
                 inputConfig, SNOWPIPE_STREAMING_MAX_MEMORY_LIMIT_IN_BYTES, invalidParams);
           }
 
+          if (inputConfig.containsKey(TASK_BUFFER_TOTAL_LIMIT_BYTES)) {
+            ensureValidLong(inputConfig, TASK_BUFFER_TOTAL_LIMIT_BYTES, invalidParams);
+          }
+
           // Valid schematization for Snowpipe Streaming
           invalidParams.putAll(validateSchematizationConfig(inputConfig));
         }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -38,6 +38,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.snowflake.ingest.utils.Constants;
+import net.snowflake.ingest.utils.ParameterProvider;
 
 /**
  * Object to convert and store properties for {@link
@@ -99,6 +100,19 @@ public class StreamingClientProperties {
     snowpipeStreamingMaxClientLag.ifPresent(
         overriddenValue ->
             parameterOverrides.put(MAX_CLIENT_LAG, String.format("%s second", overriddenValue)));
+
+    Optional<String> enableDynamicFlush =
+        Optional.ofNullable(connectorConfig.get(ENABLE_DYNAMIC_FLUSH));
+    enableDynamicFlush.ifPresent(
+        overriddenValue ->
+            parameterOverrides.put(ParameterProvider.ENABLE_DYNAMIC_FLUSH, overriddenValue));
+
+    Optional<String> taskBufferLimitBytes =
+        Optional.ofNullable(connectorConfig.get(TASK_BUFFER_TOTAL_LIMIT_BYTES));
+    taskBufferLimitBytes.ifPresent(
+        overriddenValue ->
+            parameterOverrides.put(
+                ParameterProvider.TASK_BUFFER_TOTAL_LIMIT_BYTES, overriddenValue));
 
     if (InternalBufferParameters.isSingleBufferEnabled(connectorConfig)) {
       Optional<String> bufferMaxSizeBytes =
@@ -181,6 +195,14 @@ public class StreamingClientProperties {
               clientOverridePropertiesMap,
               MAX_MEMORY_LIMIT_IN_BYTES,
               SNOWPIPE_STREAMING_MAX_MEMORY_LIMIT_IN_BYTES);
+          overrideStreamingClientPropertyIfSet(
+              clientOverridePropertiesMap,
+              ParameterProvider.ENABLE_DYNAMIC_FLUSH,
+              ENABLE_DYNAMIC_FLUSH);
+          overrideStreamingClientPropertyIfSet(
+              clientOverridePropertiesMap,
+              ParameterProvider.TASK_BUFFER_TOTAL_LIMIT_BYTES,
+              TASK_BUFFER_TOTAL_LIMIT_BYTES);
           parameterOverrides.putAll(clientOverridePropertiesMap);
         });
     parameterOverrides.forEach(

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -18,9 +18,11 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_DYNAMIC_FLUSH;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_MEMORY_LIMIT_IN_BYTES;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_BUFFER_TOTAL_LIMIT_BYTES;
 import static net.snowflake.ingest.utils.ParameterProvider.ENABLE_ICEBERG_STREAMING;
 import static net.snowflake.ingest.utils.ParameterProvider.MAX_CHANNEL_SIZE_IN_BYTES;
 import static net.snowflake.ingest.utils.ParameterProvider.MAX_CLIENT_LAG;

--- a/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1Test.java
@@ -1,0 +1,170 @@
+package com.snowflake.kafka.connector.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
+import java.util.Collections;
+import java.util.List;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SnowflakeSinkServiceV1Test {
+
+  private SnowflakeConnectionService mockConn;
+  private SnowflakeSinkServiceV1 sinkService;
+
+  private static final String TEST_TOPIC = "test_topic";
+  private static final String TEST_TABLE = "test_table";
+
+  @BeforeEach
+  void setup() {
+    mockConn = mock(SnowflakeConnectionService.class);
+    SnowflakeTelemetryService mockTelemetryService = mock(SnowflakeTelemetryService.class);
+
+    when(mockConn.isClosed()).thenReturn(false);
+    when(mockConn.getTelemetryClient()).thenReturn(mockTelemetryService);
+    when(mockConn.getConnectorName()).thenReturn(TestUtils.TEST_CONNECTOR_NAME);
+
+    sinkService = new SnowflakeSinkServiceV1(mockConn);
+  }
+
+  @Test
+  void enforceTaskBufferLimit_noFlushWhenUnderLimit() {
+    // Total buffer across pipes < limit, no flush should occur
+    sinkService.configureEnableDynamicFlush(true);
+    sinkService.configureTaskBufferLimitBytes(10_000L);
+
+    // Setup table and stage mocks
+    setupTableAndStageMocks();
+
+    // Start a partition and insert small records (under limit)
+    sinkService.startPartition(TEST_TABLE, new TopicPartition(TEST_TOPIC, 0));
+
+    List<SinkRecord> records = TestUtils.createNativeJsonSinkRecords(0, 1, TEST_TOPIC, 0);
+    sinkService.insert(records);
+
+    // Verify buffer is not empty (not flushed due to task buffer limit)
+    String pipeName = getNameIndex(TEST_TOPIC, 0);
+    assertThat(sinkService.isPartitionBufferEmpty(pipeName)).isFalse();
+  }
+
+  @Test
+  void enforceTaskBufferLimit_flushWhenOverLimit() {
+    // Configure very low limit to force flush
+    sinkService.configureEnableDynamicFlush(true);
+    sinkService.configureTaskBufferLimitBytes(1L); // Very low limit
+
+    setupTableAndStageMocks();
+
+    sinkService.startPartition(TEST_TABLE, new TopicPartition(TEST_TOPIC, 0));
+
+    List<SinkRecord> records = TestUtils.createNativeJsonSinkRecords(0, 5, TEST_TOPIC, 0);
+    sinkService.insert(records);
+
+    // With limit of 1 byte, buffer should be flushed
+    String pipeName = getNameIndex(TEST_TOPIC, 0);
+    assertThat(sinkService.isPartitionBufferEmpty(pipeName)).isTrue();
+  }
+
+  @Test
+  void enforceTaskBufferLimit_disabledByDefault() {
+    // Dynamic flush is disabled by default
+    // Large records should NOT trigger task buffer limit flush
+    sinkService.configureTaskBufferLimitBytes(1L); // Low limit but feature disabled
+
+    setupTableAndStageMocks();
+
+    sinkService.startPartition(TEST_TABLE, new TopicPartition(TEST_TOPIC, 0));
+
+    List<SinkRecord> records = TestUtils.createNativeJsonSinkRecords(0, 1, TEST_TOPIC, 0);
+    sinkService.insert(records);
+
+    // Buffer should NOT be flushed because dynamic flush is disabled
+    String pipeName = getNameIndex(TEST_TOPIC, 0);
+    assertThat(sinkService.isPartitionBufferEmpty(pipeName)).isFalse();
+  }
+
+  @Test
+  void enforceTaskBufferLimit_flushesLargestPipeFirst() {
+    sinkService.configureEnableDynamicFlush(true);
+    // Set limit low enough that total exceeds after second insert
+    // With limit of 500, after second insert the limit is exceeded
+    sinkService.configureTaskBufferLimitBytes(500L);
+
+    setupTableAndStageMocks();
+
+    // Start two partitions
+    sinkService.startPartition(TEST_TABLE, new TopicPartition(TEST_TOPIC, 0));
+    sinkService.startPartition(TEST_TABLE, new TopicPartition(TEST_TOPIC, 1));
+
+    // Insert small records to partition 0 first (under limit)
+    List<SinkRecord> smallRecords = TestUtils.createNativeJsonSinkRecords(0, 1, TEST_TOPIC, 0);
+    sinkService.insert(smallRecords);
+
+    // Insert more records to partition 1 (making it larger, exceeds limit)
+    List<SinkRecord> largeRecords = TestUtils.createNativeJsonSinkRecords(0, 10, TEST_TOPIC, 1);
+    sinkService.insert(largeRecords);
+
+    // The larger partition (1) should be flushed first
+    String pipe0 = getNameIndex(TEST_TOPIC, 0);
+    String pipe1 = getNameIndex(TEST_TOPIC, 1);
+
+    // Verify partition 1 (larger) was flushed, partition 0 was not flushed
+    assertThat(sinkService.isPartitionBufferEmpty(pipe1)).isTrue();
+    assertThat(sinkService.isPartitionBufferEmpty(pipe0)).isFalse();
+  }
+
+  @Test
+  void enforceTaskBufferLimit_flushesMultiplePipesIfNeeded() {
+    sinkService.configureEnableDynamicFlush(true);
+    sinkService.configureTaskBufferLimitBytes(1L); // Force flush all
+
+    setupTableAndStageMocks();
+
+    // Start multiple partitions
+    sinkService.startPartition(TEST_TABLE, new TopicPartition(TEST_TOPIC, 0));
+    sinkService.startPartition(TEST_TABLE, new TopicPartition(TEST_TOPIC, 1));
+    sinkService.startPartition(TEST_TABLE, new TopicPartition(TEST_TOPIC, 2));
+
+    // Insert records to all partitions
+    sinkService.insert(TestUtils.createNativeJsonSinkRecords(0, 2, TEST_TOPIC, 0));
+    sinkService.insert(TestUtils.createNativeJsonSinkRecords(0, 2, TEST_TOPIC, 1));
+    sinkService.insert(TestUtils.createNativeJsonSinkRecords(0, 2, TEST_TOPIC, 2));
+
+    // All pipes should be flushed due to very low limit
+    assertThat(sinkService.isPartitionBufferEmpty(getNameIndex(TEST_TOPIC, 0))).isTrue();
+    assertThat(sinkService.isPartitionBufferEmpty(getNameIndex(TEST_TOPIC, 1))).isTrue();
+    assertThat(sinkService.isPartitionBufferEmpty(getNameIndex(TEST_TOPIC, 2))).isTrue();
+  }
+
+  @Test
+  void enforceTaskBufferLimit_noPipesIsNoOp() {
+    sinkService.configureEnableDynamicFlush(true);
+    sinkService.configureTaskBufferLimitBytes(1L);
+
+    // Insert with empty records list - no pipes started
+    sinkService.insert(Collections.emptyList());
+
+    // Should not throw, just a no-op
+  }
+
+  // Helper method to setup common table and stage mocks
+  private void setupTableAndStageMocks() {
+    when(mockConn.tableExist(TEST_TABLE)).thenReturn(true);
+    when(mockConn.isTableCompatible(TEST_TABLE)).thenReturn(true);
+    when(mockConn.stageExist(anyString())).thenReturn(true);
+    when(mockConn.isStageCompatible(anyString())).thenReturn(true);
+    when(mockConn.listStage(anyString(), anyString())).thenReturn(Collections.emptyList());
+    when(mockConn.pipeExist(anyString())).thenReturn(false);
+  }
+
+  // Helper method to generate pipe name index (same logic as in SnowflakeSinkServiceV1)
+  private String getNameIndex(String topic, int partition) {
+    return topic + "_" + partition;
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidatorTest.java
@@ -225,12 +225,19 @@ public class TaskToTopicPartitionValidatorTest {
       ConnectException exception =
           assertThrows(ConnectException.class, validator::validateTaskToTopicPartitions);
 
+      // Verify message contains required tasks for current config
       String expectedMessage = "tasks.max to at least " + expectedRequiredTasks;
       Assertions.assertTrue(
           exception.getMessage().contains(expectedMessage),
           "Exception message should contain 'tasks.max to at least "
               + expectedRequiredTasks
               + "' but was: "
+              + exception.getMessage());
+
+      // Verify message suggests enabling dynamic flush (since it's not enabled)
+      Assertions.assertTrue(
+          exception.getMessage().contains("enable.dynamic.flush"),
+          "Exception message should suggest enabling dynamic flush but was: "
               + exception.getMessage());
     } else {
       // Should pass without exception
@@ -368,5 +375,45 @@ public class TaskToTopicPartitionValidatorTest {
     // Shutdown the validator
     validator.shutdown();
     validator.join(1000);
+  }
+
+  /**
+   * Test that when enable.dynamic.flush is true but memory still exceeds 2x limit, error message
+   * does NOT suggest enabling dynamic flush (already enabled). With 150 partitions * 10MB = 1500MB
+   * > 1000MB (2x limit) -> fails requiredTasks = ceil(1500/1000) = 2
+   */
+  @Test
+  public void testValidate_WithDynamicFlushEnabled_ExceedsLimit() throws Exception {
+    config.put(SnowflakeSinkConnectorConfig.ENABLE_DYNAMIC_FLUSH, "true");
+    config.put(TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION, "fail");
+    validator =
+        new TaskToTopicPartitionValidator(config, adminClient, failure, TEST_TASK_CONFIG_ID);
+
+    // 150 partitions * 10MB = 1500MB > 1000MB (2x limit)
+    TopicDescription topicDescription =
+        new TopicDescription(
+            "test-topic", false, Collections.nCopies(150, mock(TopicPartitionInfo.class)));
+
+    Map<String, TopicDescription> descriptions = new HashMap<>();
+    descriptions.put("test-topic", topicDescription);
+
+    when(adminClient.describeTopics(anyCollection())).thenReturn(describeTopicsResult);
+    when(describeTopicsResult.allTopicNames()).thenReturn(kafkaFuture);
+    when(kafkaFuture.get()).thenReturn(descriptions);
+
+    // Should throw exception
+    ConnectException exception =
+        assertThrows(ConnectException.class, validator::validateTaskToTopicPartitions);
+
+    // Verify message contains required tasks (ceil(1500/1000) = 2)
+    Assertions.assertTrue(
+        exception.getMessage().contains("tasks.max to at least 2"),
+        "Exception message should suggest at least 2 tasks but was: " + exception.getMessage());
+
+    // Verify message does NOT suggest enabling dynamic flush (already enabled)
+    Assertions.assertFalse(
+        exception.getMessage().contains("or enable"),
+        "Exception message should NOT suggest enabling dynamic flush when already enabled but was: "
+            + exception.getMessage());
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidatorTest.java
@@ -218,7 +218,7 @@ public class TaskToTopicPartitionValidatorTest {
 
     // Calculate expected memory usage
     long expectedMemoryUsage = partitions * bufferSize;
-    long memoryLimit = 500 * 1024 * 1024; // 500MB
+    long memoryLimit = 500 * 1000 * 1000;
 
     if (expectedMemoryUsage > memoryLimit) {
       // Should throw exception with correct requiredTasks in message


### PR DESCRIPTION
https://confluentinc.atlassian.net/wiki/spaces/~712020d7bfb4a0cfcc48d2a32542edfd7193a0/pages/5115871821/Cost+and+Performance+Impact+of+Task+Buffer+Limit+for+Snowflake+Sink+Connector

https://confluentinc.atlassian.net/wiki/spaces/~712020d7bfb4a0cfcc48d2a32542edfd7193a0/pages/5274927639/Load+testing+with+enableDynamicFlush