### PR TITLE
Log warn message if task to topic partition validation fails

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -294,16 +294,17 @@ public class SnowflakeSinkConnectorConfig {
           "com.snowflake.kafka.connector.records.SnowflakeAvroConverterWithoutSchemaRegistry",
           "com.snowflake.kafka.connector.records.SnowflakeAvroConverter");
 
-  public static final String ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION =
-      "enable.task.to.topic.partitions.validation";
-  public static final Boolean ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION_DEFAULT = true;
+  public static final String TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION =
+      "task.to.topic.partitions.validation.failure.action";
+  public static final String TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION_DEFAULT =
+      TaskToTopicPartitionValidatorFailureAction.WARN.toString();
   public static final String TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS =
       "task.to.topic.partitions.validation.interval.ms";
   public static final long TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS_DEFAULT =
       3600000; // 1 hour
-  public static final String TASK_TO_TOPIC_PARTITIONS_MEMORY_LIMIT_IN_BYTES =
-      "task.to.topic.partitions.memory.limit.bytes";
-  public static final long TASK_TO_TOPIC_PARTITIONS_MEMORY_LIMIT_IN_BYTES_DEFAULT =
+  public static final String TASK_TO_TOPIC_PARTITIONS_VALIDATION_MEMORY_LIMIT_IN_BYTES =
+      "task.to.topic.partitions.validation.memory.limit.bytes";
+  public static final long TASK_TO_TOPIC_PARTITIONS_VALIDATION_MEMORY_LIMIT_IN_BYTES_DEFAULT =
       524288000; // 500MB
 
   public static void setDefaultValues(Map<String, String> config) {
@@ -533,4 +534,50 @@ public class SnowflakeSinkConnectorConfig {
           this.validator.ensureValid(name, value);
         }
       };
+
+  /** Enum for task to topic partition validator failure action. */
+  public enum TaskToTopicPartitionValidatorFailureAction {
+    /** Fail the task when validation fails. */
+    FAIL,
+
+    /** Only log a warning when validation fails. */
+    WARN;
+
+    /** Validator for the failure action config. */
+    public static final ConfigDef.Validator VALIDATOR =
+        new ConfigDef.Validator() {
+          private final ConfigDef.ValidString validator =
+              ConfigDef.ValidString.in(TaskToTopicPartitionValidatorFailureAction.names());
+
+          @Override
+          public void ensureValid(String name, Object value) {
+            if (value instanceof String) {
+              value = ((String) value).toLowerCase(Locale.ROOT);
+            }
+            validator.ensureValid(name, value);
+          }
+
+          @Override
+          public String toString() {
+            return validator.toString();
+          }
+        };
+
+    /** @return All valid enum values as lowercase strings */
+    public static String[] names() {
+      TaskToTopicPartitionValidatorFailureAction[] actions = values();
+      String[] result = new String[actions.length];
+
+      for (int i = 0; i < actions.length; i++) {
+        result[i] = actions[i].toString();
+      }
+
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return name().toLowerCase(Locale.ROOT);
+    }
+  }
 }

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -300,7 +300,7 @@ public class SnowflakeSinkConnectorConfig {
   public static final String TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS =
       "task.to.topic.partitions.validation.interval.ms";
   public static final long TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS_DEFAULT =
-      300000; // 5 minutes
+      3600000; // 1 hour
   public static final String TASK_TO_TOPIC_PARTITIONS_MEMORY_LIMIT_IN_BYTES =
       "task.to.topic.partitions.memory.limit.bytes";
   public static final long TASK_TO_TOPIC_PARTITIONS_MEMORY_LIMIT_IN_BYTES_DEFAULT =

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -296,7 +296,7 @@ public class SnowflakeSinkConnectorConfig {
 
   public static final String ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION =
       "enable.task.to.topic.partitions.validation";
-  public static final Boolean ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION_DEFAULT = false;
+  public static final Boolean ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION_DEFAULT = true;
   public static final String TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS =
       "task.to.topic.partitions.validation.interval.ms";
   public static final long TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS_DEFAULT =

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -294,6 +294,9 @@ public class SnowflakeSinkConnectorConfig {
           "com.snowflake.kafka.connector.records.SnowflakeAvroConverterWithoutSchemaRegistry",
           "com.snowflake.kafka.connector.records.SnowflakeAvroConverter");
 
+  public static final String ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION =
+      "enable.task.to.topic.partitions.validation";
+  public static final Boolean ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION_DEFAULT = true;
   public static final String TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION =
       "task.to.topic.partitions.validation.failure.action";
   public static final String TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION_DEFAULT =

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -242,11 +242,22 @@ public class SnowflakeSinkTask extends SinkTask {
             .build();
 
     // Start task to topic partition validator
-    taskToTopicPartitionValidator =
-        new TaskToTopicPartitionValidator(
-            parsedConfig, taskToTopicPartitionValidatorFailure, this.taskConfigId);
-    taskToTopicPartitionValidator.runInitialValidation();
-    taskToTopicPartitionValidator.start();
+    boolean enableTaskToTopicPartitionsValidation =
+        SnowflakeSinkConnectorConfig.ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION_DEFAULT;
+    if (parsedConfig.containsKey(
+        SnowflakeSinkConnectorConfig.ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION)) {
+      enableTaskToTopicPartitionsValidation =
+          Boolean.parseBoolean(
+              parsedConfig.get(
+                  SnowflakeSinkConnectorConfig.ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION));
+    }
+    if (enableTaskToTopicPartitionsValidation) {
+      taskToTopicPartitionValidator =
+          new TaskToTopicPartitionValidator(
+              parsedConfig, taskToTopicPartitionValidatorFailure, this.taskConfigId);
+      taskToTopicPartitionValidator.runInitialValidation();
+      taskToTopicPartitionValidator.start();
+    }
 
     DYNAMIC_LOGGER.info(
         "task started, execution time: {} milliseconds",

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -242,22 +242,11 @@ public class SnowflakeSinkTask extends SinkTask {
             .build();
 
     // Start task to topic partition validator
-    boolean enableTaskToTopicPartitionsValidation =
-        SnowflakeSinkConnectorConfig.ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION_DEFAULT;
-    if (parsedConfig.containsKey(
-        SnowflakeSinkConnectorConfig.ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION)) {
-      enableTaskToTopicPartitionsValidation =
-          Boolean.parseBoolean(
-              parsedConfig.get(
-                  SnowflakeSinkConnectorConfig.ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION));
-    }
-    if (enableTaskToTopicPartitionsValidation) {
-      taskToTopicPartitionValidator =
-          new TaskToTopicPartitionValidator(
-              parsedConfig, taskToTopicPartitionValidatorFailure, this.taskConfigId);
-      taskToTopicPartitionValidator.runInitialValidation();
-      taskToTopicPartitionValidator.start();
-    }
+    taskToTopicPartitionValidator =
+        new TaskToTopicPartitionValidator(
+            parsedConfig, taskToTopicPartitionValidatorFailure, this.taskConfigId);
+    taskToTopicPartitionValidator.runInitialValidation();
+    taskToTopicPartitionValidator.start();
 
     DYNAMIC_LOGGER.info(
         "task started, execution time: {} milliseconds",

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -625,18 +625,20 @@ public class ConnectorConfigDefinition {
             ConfigDef.Importance.LOW,
             "The interval (in milliseconds) at which the task-to-topic-partitions validator runs.")
         .define(
-            TASK_TO_TOPIC_PARTITIONS_MEMORY_LIMIT_IN_BYTES,
+            TASK_TO_TOPIC_PARTITIONS_VALIDATION_MEMORY_LIMIT_IN_BYTES,
             ConfigDef.Type.LONG,
-            TASK_TO_TOPIC_PARTITIONS_MEMORY_LIMIT_IN_BYTES_DEFAULT,
+            TASK_TO_TOPIC_PARTITIONS_VALIDATION_MEMORY_LIMIT_IN_BYTES_DEFAULT,
             ConfigDef.Importance.LOW,
             "The maximum amount of memory (in bytes) allocated per task for validating"
                 + " task-to-topic-partitions.")
         .define(
-            ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION,
-            ConfigDef.Type.BOOLEAN,
-            ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION_DEFAULT,
+            TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION,
+            ConfigDef.Type.STRING,
+            TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION_DEFAULT,
+            SnowflakeSinkConnectorConfig.TaskToTopicPartitionValidatorFailureAction.VALIDATOR,
             ConfigDef.Importance.LOW,
-            "Enable task to topic partitions validation to detect any misconfiguration between the"
-                + " number of tasks and assigned topic partitions.");
+            "Action to take when task to topic partitions validation fails. "
+                + "Allowed values are: 'fail' (throw exception and fail the task) or "
+                + "'warn' (log a warning message only).");
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -632,6 +632,13 @@ public class ConnectorConfigDefinition {
             "The maximum amount of memory (in bytes) allocated per task for validating"
                 + " task-to-topic-partitions.")
         .define(
+            ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION,
+            ConfigDef.Type.BOOLEAN,
+            ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION_DEFAULT,
+            ConfigDef.Importance.LOW,
+            "Enable task to topic partitions validation to detect any misconfiguration between the"
+                + " number of tasks and assigned topic partitions.")
+        .define(
             TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION,
             ConfigDef.Type.STRING,
             TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION_DEFAULT,

--- a/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
@@ -85,7 +85,7 @@ public class TaskToTopicPartitionValidator extends Thread {
       try {
         initializeAdminClient();
       } catch (Exception e) {
-        throw fail(e, "Error while initializing AdminClient for TaskToTopicPartitionValidator");
+        fail(e, "Error while initializing AdminClient for TaskToTopicPartitionValidator");
       }
     }
     try {
@@ -93,7 +93,7 @@ public class TaskToTopicPartitionValidator extends Thread {
         try {
           validateTaskToTopicPartitions();
         } catch (ConnectException e) {
-          throw fail(e, "Error while running TaskToTopicPartition validation");
+          fail(e, "Error while running TaskToTopicPartition validation");
         }
         try {
           long jitterMs = ThreadLocalRandom.current().nextLong(0, 5000);
@@ -125,7 +125,7 @@ public class TaskToTopicPartitionValidator extends Thread {
    * Run initial validation synchronously before starting the thread. This method should be called
    * before start() to fail fast if validation fails.
    *
-   * @throws ConnectException if validation fails
+   * @throws ConnectException if validation fails and failure action is set to FAIL.
    */
   public void runInitialValidation() {
     LOGGER.info("Running initial TaskToTopicPartition validation...");
@@ -134,11 +134,11 @@ public class TaskToTopicPartitionValidator extends Thread {
         initializeAdminClient();
       }
       validateTaskToTopicPartitions();
+      LOGGER.info("Initial TaskToTopicPartition validation passed.");
     } catch (Exception e) {
       closeAdminClient();
-      throw fail(e, "Error while running initial TaskToTopicPartition validation.");
+      fail(e, "Error while running initial TaskToTopicPartition validation.");
     }
-    LOGGER.info("Initial TaskToTopicPartition validation passed.");
   }
 
   private void initializeAdminClient() {
@@ -297,20 +297,19 @@ public class TaskToTopicPartitionValidator extends Thread {
 
   /**
    * Fail the connector with an unrecoverable error and stop the validator thread
-   *
+   * if the failure action is set to FAIL. Otherwise, just log the error.
    * @param t the cause of the failure
-   * @return a {@link RuntimeException} that can be thrown from the calling method
+   * @param message additional message to log with the error
    */
-  private RuntimeException fail(Throwable t, String message) {
-    RuntimeException exception = new ConnectException(message, t);
+  private void fail(Throwable t, String message) {
+    shutdownLatch.countDown();
     if (this.failureAction == TaskToTopicPartitionValidatorFailureAction.FAIL) {
       LOGGER.error(message, t);
+      RuntimeException exception = new ConnectException(message, t);
       failure.set(exception);
+      throw exception;
     } else {
       LOGGER.warn(message, t);
     }
-    // Preemptively shut down the monitoring thread
-    shutdownLatch.countDown();
-    return exception;
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
@@ -136,7 +136,10 @@ public class TaskToTopicPartitionValidator extends Thread {
       validateTaskToTopicPartitions();
     } catch (ConnectException e) {
       closeAdminClient();
-      throw e;
+      throw fail(e, "Initial TaskToTopicPartition validation failed");
+    } catch (Exception e) {
+      closeAdminClient();
+      throw fail(e, "Error while running initial TaskToTopicPartition validation");
     }
     LOGGER.info("Initial TaskToTopicPartition validation passed.");
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
@@ -11,6 +11,7 @@ import com.snowflake.kafka.connector.Utils;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
@@ -85,8 +86,12 @@ public class TaskToTopicPartitionValidator extends Thread {
           throw fail(e, "Error while running TaskToTopicPartition validation");
         }
         try {
-          LOGGER.debug("Waiting {} ms to check for buffer size validation.", validationIntervalMs);
-          boolean shuttingDown = shutdownLatch.await(validationIntervalMs, TimeUnit.MILLISECONDS);
+          long jitterMs = ThreadLocalRandom.current().nextLong(0, 5000);
+          LOGGER.debug(
+              "Waiting {} ms to check for buffer size validation.",
+              validationIntervalMs + jitterMs);
+          boolean shuttingDown =
+              shutdownLatch.await(validationIntervalMs + jitterMs, TimeUnit.MILLISECONDS);
           if (shuttingDown) {
             return;
           }
@@ -231,9 +236,10 @@ public class TaskToTopicPartitionValidator extends Thread {
               "Total memory usage per task (%d bytes) exceeds limit (%d bytes). "
                   + "Please increase the tasks.max to at least %d.",
               totalMemoryUsage, this.memoryLimitBytes, requiredTasks);
-
+      LOGGER.warn(errorMessage);
       // This will be caught by the run() loop and call fail()
-      throw new ConnectException(errorMessage);
+      // TODO throw this exception later, warn as of now!
+      // throw new ConnectException(errorMessage);
     }
   }
 
@@ -284,7 +290,8 @@ public class TaskToTopicPartitionValidator extends Thread {
   private RuntimeException fail(Throwable t, String message) {
     LOGGER.error(message, t);
     RuntimeException exception = new ConnectException(message, t);
-    failure.set(exception);
+    // TODO do not set failure here to avoid connector failure
+    // failure.set(exception);
     // Preemptively shut down the monitoring thread
     shutdownLatch.countDown();
     return exception;

--- a/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
@@ -134,12 +134,9 @@ public class TaskToTopicPartitionValidator extends Thread {
         initializeAdminClient();
       }
       validateTaskToTopicPartitions();
-    } catch (ConnectException e) {
-      closeAdminClient();
-      throw fail(e, "Initial TaskToTopicPartition validation failed");
     } catch (Exception e) {
       closeAdminClient();
-      throw fail(e, "Error while running initial TaskToTopicPartition validation");
+      throw fail(e, "Error while running initial TaskToTopicPartition validation.");
     }
     LOGGER.info("Initial TaskToTopicPartition validation passed.");
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
@@ -302,8 +302,8 @@ public class TaskToTopicPartitionValidator extends Thread {
    * @param message additional message to log with the error
    */
   private void fail(Throwable t, String message) {
-    shutdownLatch.countDown();
     if (this.failureAction == TaskToTopicPartitionValidatorFailureAction.FAIL) {
+      shutdownLatch.countDown();
       LOGGER.error(message, t);
       RuntimeException exception = new ConnectException(message, t);
       failure.set(exception);

--- a/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
@@ -1,12 +1,15 @@
 package com.snowflake.kafka.connector.internal;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_TO_TOPIC_PARTITIONS_MEMORY_LIMIT_IN_BYTES;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_TO_TOPIC_PARTITIONS_MEMORY_LIMIT_IN_BYTES_DEFAULT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION_DEFAULT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS_DEFAULT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_TO_TOPIC_PARTITIONS_VALIDATION_MEMORY_LIMIT_IN_BYTES;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_TO_TOPIC_PARTITIONS_VALIDATION_MEMORY_LIMIT_IN_BYTES_DEFAULT;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TaskToTopicPartitionValidatorFailureAction;
 import com.snowflake.kafka.connector.Utils;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
@@ -36,6 +39,7 @@ public class TaskToTopicPartitionValidator extends Thread {
   private final CountDownLatch shutdownLatch;
   private final long validationIntervalMs;
   private final long memoryLimitBytes;
+  private final TaskToTopicPartitionValidatorFailureAction failureAction;
   private AdminClient adminClient;
 
   public TaskToTopicPartitionValidator(
@@ -59,8 +63,14 @@ public class TaskToTopicPartitionValidator extends Thread {
     this.memoryLimitBytes =
         Long.parseLong(
             config.getOrDefault(
-                TASK_TO_TOPIC_PARTITIONS_MEMORY_LIMIT_IN_BYTES,
-                String.valueOf(TASK_TO_TOPIC_PARTITIONS_MEMORY_LIMIT_IN_BYTES_DEFAULT)));
+                TASK_TO_TOPIC_PARTITIONS_VALIDATION_MEMORY_LIMIT_IN_BYTES,
+                String.valueOf(TASK_TO_TOPIC_PARTITIONS_VALIDATION_MEMORY_LIMIT_IN_BYTES_DEFAULT)));
+    String failureActionStr =
+        config.getOrDefault(
+            TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION,
+            TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION_DEFAULT);
+    this.failureAction =
+        TaskToTopicPartitionValidatorFailureAction.valueOf(failureActionStr.toUpperCase());
     this.shutdownLatch = new CountDownLatch(1);
     this.setName(
         config.get(Utils.NAME) + "-" + taskConfigId + "-task-to-topic-partitions-validator");
@@ -236,10 +246,14 @@ public class TaskToTopicPartitionValidator extends Thread {
               "Total memory usage per task (%d bytes) exceeds limit (%d bytes). "
                   + "Please increase the tasks.max to at least %d.",
               totalMemoryUsage, this.memoryLimitBytes, requiredTasks);
-      LOGGER.warn(errorMessage);
-      // This will be caught by the run() loop and call fail()
-      // TODO throw this exception later, warn as of now!
-      // throw new ConnectException(errorMessage);
+
+      if (this.failureAction == TaskToTopicPartitionValidatorFailureAction.FAIL) {
+        LOGGER.error(errorMessage);
+        // This will be caught by the run() loop and call fail()
+        throw new ConnectException(errorMessage);
+      } else {
+        LOGGER.warn(errorMessage);
+      }
     }
   }
 
@@ -288,10 +302,13 @@ public class TaskToTopicPartitionValidator extends Thread {
    * @return a {@link RuntimeException} that can be thrown from the calling method
    */
   private RuntimeException fail(Throwable t, String message) {
-    LOGGER.error(message, t);
     RuntimeException exception = new ConnectException(message, t);
-    // TODO do not set failure here to avoid connector failure
-    // failure.set(exception);
+    if (this.failureAction == TaskToTopicPartitionValidatorFailureAction.FAIL) {
+      LOGGER.error(message, t);
+      failure.set(exception);
+    } else {
+      LOGGER.warn(message, t);
+    }
     // Preemptively shut down the monitoring thread
     shutdownLatch.countDown();
     return exception;

--- a/src/test/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidatorTest.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.anyCollection;
@@ -23,7 +24,6 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -89,8 +89,12 @@ public class TaskToTopicPartitionValidatorTest {
   }
 
   @Test
-  @Disabled("validateTaskToTopicPartitions is only logging warnings currently")
-  public void testValidate_HighUsage() throws Exception {
+  public void testValidate_HighUsage_WithFailAction() throws Exception {
+    // Set failure action to FAIL
+    config.put(TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION, "fail");
+    validator =
+        new TaskToTopicPartitionValidator(config, adminClient, failure, TEST_TASK_CONFIG_ID);
+
     // Increase partitions to exceed 500MB with 10MB buffer size (requires > 50 partitions)
     // 60 partitions * 10MB = 600MB > 500MB
     TopicDescription topicDescription =
@@ -109,6 +113,36 @@ public class TaskToTopicPartitionValidatorTest {
 
     // Verify interactions
     verify(adminClient).describeTopics(anyCollection());
+  }
+
+  @Test
+  public void testValidate_HighUsage_WithWarnAction() throws Exception {
+    // Set failure action to WARN (default)
+    config.put(TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION, "warn");
+    validator =
+        new TaskToTopicPartitionValidator(config, adminClient, failure, TEST_TASK_CONFIG_ID);
+
+    // Increase partitions to exceed 500MB with 10MB buffer size (requires > 50 partitions)
+    // 60 partitions * 10MB = 600MB > 500MB
+    TopicDescription topicDescription =
+        new TopicDescription(
+            "test-topic", false, Collections.nCopies(60, mock(TopicPartitionInfo.class)));
+
+    Map<String, TopicDescription> descriptions = new HashMap<>();
+    descriptions.put("test-topic", topicDescription);
+
+    when(adminClient.describeTopics(anyCollection())).thenReturn(describeTopicsResult);
+    when(describeTopicsResult.allTopicNames()).thenReturn(kafkaFuture);
+    when(kafkaFuture.get()).thenReturn(descriptions);
+
+    // Execute validation (should NOT throw exception, only warn)
+    validator.validateTaskToTopicPartitions();
+
+    // Verify interactions
+    verify(adminClient).describeTopics(anyCollection());
+
+    // Verify no failure was set
+    Assertions.assertNull(failure.get(), "No failure should be set for warn action");
   }
 
   @Test
@@ -152,7 +186,6 @@ public class TaskToTopicPartitionValidatorTest {
    * ceil(5000/500) = 10
    */
   @ParameterizedTest
-  @Disabled("validateTaskToTopicPartitions is only logging warnings currently")
   @CsvSource({
     "100, 10000000, 2", // 100 partitions * 10MB = 1000MB -> ceil(1000/500) = 2
     "150, 10000000, 3", // 150 partitions * 10MB = 1500MB -> ceil(1500/500) = 3
@@ -163,9 +196,10 @@ public class TaskToTopicPartitionValidatorTest {
   })
   public void testRequiredTasksCalculation(
       int partitions, long bufferSize, long expectedRequiredTasks) throws Exception {
-    // Setup config with specified buffer size
+    // Setup config with specified buffer size and FAIL action
     config.put(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES, String.valueOf(bufferSize));
     config.put("tasks.max", "1");
+    config.put(TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION, "fail");
     failure = new AtomicReference<>();
     validator =
         new TaskToTopicPartitionValidator(config, adminClient, failure, TEST_TASK_CONFIG_ID);
@@ -209,16 +243,16 @@ public class TaskToTopicPartitionValidatorTest {
   /**
    * Test the full thread lifecycle where partition count increases mid-run and fails the connector.
    *
-   * <p>Scenario: 1. Thread starts with a short validation interval (500ms) 2. First validation call
+   * <p>Scenario: 1. Thread starts with a short validation interval (200ms) 2. First validation call
    * returns 10 partitions (passes - 10 * 10MB = 100MB < 500MB) 3. Second validation call returns
    * 100 partitions (fails - 100 * 10MB = 1000MB > 500MB) 4. Verify failure AtomicReference is set
    */
   @Test
-  @Disabled("validateTaskToTopicPartitions is only logging warnings currently")
   public void testThreadLifecycle_PartitionCountIncreases_FailsConnector() throws Exception {
-    // Use a short validation interval for testing (500ms)
+    // Use a short validation interval for testing (200ms) and FAIL action
     failure = new AtomicReference<>();
-    config.put(TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS, String.valueOf(500));
+    config.put(TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS, String.valueOf(200));
+    config.put(TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION, "fail");
     validator =
         new TaskToTopicPartitionValidator(config, adminClient, failure, TEST_TASK_CONFIG_ID);
 
@@ -257,10 +291,10 @@ public class TaskToTopicPartitionValidatorTest {
     // Wait for the thread to process at least 2 validation cycles
     // The thread should:
     // 1. Run first validation (pass)
-    // 2. Wait 500ms
+    // 2. Wait 200ms
     // 3. Run second validation (fail)
     // 4. Set failure and stop
-    verify(adminClient, timeout(3000).atLeast(2)).describeTopics(anyCollection());
+    verify(adminClient, timeout(10000).atLeast(2)).describeTopics(anyCollection());
 
     // Wait for the thread to fully stop
     validator.join(1000);
@@ -273,5 +307,66 @@ public class TaskToTopicPartitionValidatorTest {
     // The thread should have stopped itself after failing
     Assertions.assertFalse(
         validator.isAlive(), "Validator thread should not be alive after failure");
+  }
+
+  /**
+   * Test the full thread lifecycle with WARN action - connector should not fail even when
+   * validation fails.
+   */
+  @Test
+  public void testThreadLifecycle_PartitionCountIncreases_WarnOnly() throws Exception {
+    // Use a short validation interval for testing (200ms) and WARN action
+    failure = new AtomicReference<>();
+    config.put(TASK_TO_TOPIC_PARTITIONS_VALIDATION_INTERVAL_MS, String.valueOf(200));
+    config.put(TASK_TO_TOPIC_PARTITIONS_VALIDATION_FAILURE_ACTION, "warn");
+    validator =
+        new TaskToTopicPartitionValidator(config, adminClient, failure, TEST_TASK_CONFIG_ID);
+
+    // Track how many times describeTopics is called
+    AtomicInteger callCount = new AtomicInteger(0);
+
+    // Create topic descriptions - first call has few partitions, second has many
+    TopicDescription fewPartitions =
+        new TopicDescription(
+            "test-topic", false, Collections.nCopies(10, mock(TopicPartitionInfo.class)));
+    TopicDescription manyPartitions =
+        new TopicDescription(
+            "test-topic", false, Collections.nCopies(100, mock(TopicPartitionInfo.class)));
+
+    // Setup mock to return different partition counts on successive calls
+    when(adminClient.describeTopics(anyCollection())).thenReturn(describeTopicsResult);
+    when(describeTopicsResult.allTopicNames()).thenReturn(kafkaFuture);
+    when(kafkaFuture.get())
+        .thenAnswer(
+            (InvocationOnMock invocation) -> {
+              int count = callCount.incrementAndGet();
+              Map<String, TopicDescription> descriptions = new HashMap<>();
+              if (count == 1) {
+                // First call: few partitions (passes)
+                descriptions.put("test-topic", fewPartitions);
+              } else {
+                // Second call onwards: many partitions (would fail with FAIL action, but only
+                // warns)
+                descriptions.put("test-topic", manyPartitions);
+              }
+              return descriptions;
+            });
+
+    // Start the validator thread
+    validator.start();
+
+    // Wait for the thread to process at least 2 validation cycles
+    verify(adminClient, timeout(5000).atLeast(2)).describeTopics(anyCollection());
+
+    // Thread should still be alive since WARN action doesn't stop the thread
+    Assertions.assertTrue(
+        validator.isAlive(), "Validator thread should still be alive with warn action");
+
+    // Verify that failure was NOT set
+    Assertions.assertNull(failure.get(), "No failure should be set for warn action");
+
+    // Shutdown the validator
+    validator.shutdown();
+    validator.join(1000);
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidatorTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -88,6 +89,7 @@ public class TaskToTopicPartitionValidatorTest {
   }
 
   @Test
+  @Disabled("validateTaskToTopicPartitions is only logging warnings currently")
   public void testValidate_HighUsage() throws Exception {
     // Increase partitions to exceed 500MB with 10MB buffer size (requires > 50 partitions)
     // 60 partitions * 10MB = 600MB > 500MB
@@ -150,6 +152,7 @@ public class TaskToTopicPartitionValidatorTest {
    * ceil(5000/500) = 10
    */
   @ParameterizedTest
+  @Disabled("validateTaskToTopicPartitions is only logging warnings currently")
   @CsvSource({
     "100, 10000000, 2", // 100 partitions * 10MB = 1000MB -> ceil(1000/500) = 2
     "150, 10000000, 3", // 150 partitions * 10MB = 1500MB -> ceil(1500/500) = 3
@@ -211,6 +214,7 @@ public class TaskToTopicPartitionValidatorTest {
    * 100 partitions (fails - 100 * 10MB = 1000MB > 500MB) 4. Verify failure AtomicReference is set
    */
   @Test
+  @Disabled("validateTaskToTopicPartitions is only logging warnings currently")
   public void testThreadLifecycle_PartitionCountIncreases_FailsConnector() throws Exception {
     // Use a short validation interval for testing (500ms)
     failure = new AtomicReference<>();


### PR DESCRIPTION
1. Increase the default validation interval to 1 hour. 
2. Add jitter of 5 seconds in the validation interval.
3. Add task.to.topic.partitions.validation.failure.action flag and when action is WARN, do not throw connect exception and do not set the failure, instead log the warning.

Testing 
Logging warn message only if action set to WARN (default), memory.limit.bytes and interval config works as expected! 
<img width="1718" height="569" alt="Screenshot 2026-02-09 at 11 32 17 AM" src="https://github.com/user-attachments/assets/9dd979e0-58b4-41f6-9751-1390f0307019" />


Running hourly with jitter 
<img width="1714" height="519" alt="Screenshot 2026-02-06 at 2 14 31 PM" src="https://github.com/user-attachments/assets/1c4316b0-8b5c-4841-8731-37f234166940" />

when failure.action is set to FAIL

<img width="690" height="314" alt="Screenshot 2026-02-09 at 11 44 49 AM" src="https://github.com/user-attachments/assets/8e6a95da-b954-4ba6-a7fc-a28e7b019e8c" />
<img width="1060" height="467" alt="Screenshot 2026-02-09 at 11 43 19 AM" src="https://github.com/user-attachments/assets/46eb92ec-de53-4b5a-b70d-710fc595aec0" />
<img width="1421" height="484" alt="Screenshot 2026-02-09 at 11 44 34 AM" src="https://github.com/user-attachments/assets/785d0183-ead0-474f-88ca-55aa4f5b006f" />


