### PR TITLE
CC-39257: Add shard profiles for parallel integration test execution

### DIFF
--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -854,6 +854,125 @@
                 </plugins>
             </build>
         </profile>
+
+        <!-- Shard profiles for parallel CI execution -->
+        <!-- Shard 1: Core tests (catch-all — new tests land here automatically) -->
+        <profile>
+            <id>shard-1</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.22.2</version>
+                        <configuration>
+                            <includes>
+                                <include>**/*IT.java</include>
+                            </includes>
+                            <excludes>
+                                <!-- Shard 2: Streaming tests -->
+                                <exclude>**/SnowflakeSinkTaskForStreamingIT.java</exclude>
+                                <exclude>**/SnowflakeSinkServiceV2IT.java</exclude>
+                                <exclude>**/SnowflakeSinkServiceV2StopIT.java</exclude>
+                                <exclude>**/SnowflakeSinkServiceV2AvroSchematizationIT.java</exclude>
+                                <exclude>**/TopicPartitionChannelIT.java</exclude>
+                                <exclude>**/CloseTopicPartitionChannelIT.java</exclude>
+                                <exclude>**/StreamingClientProviderIT.java</exclude>
+                                <exclude>**/TombstoneRecordIngestionIT.java</exclude>
+                                <!-- Shard 3: Iceberg + Connect cluster tests -->
+                                <exclude>**/IcebergIngestionSchemaEvolutionIT.java</exclude>
+                                <exclude>**/IcebergIngestionNoSchemaEvolutionIT.java</exclude>
+                                <exclude>**/IcebergTableSchemaValidatorIT.java</exclude>
+                                <exclude>**/IcebergInitServiceIT.java</exclude>
+                                <exclude>**/IcebergIngestionIT.java</exclude>
+                                <exclude>**/BaseIcebergIT.java</exclude>
+                                <exclude>**/SmtIT.java</exclude>
+                                <exclude>**/SnowflakeTelemetryPipeStatusMetricsIT.java</exclude>
+                            </excludes>
+                            <skipTests>${skipIntegrationTests}</skipTests>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- Shard 2: Streaming tests -->
+        <profile>
+            <id>shard-2</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.22.2</version>
+                        <configuration>
+                            <includes>
+                                <include>**/SnowflakeSinkTaskForStreamingIT.java</include>
+                                <include>**/SnowflakeSinkServiceV2IT.java</include>
+                                <include>**/SnowflakeSinkServiceV2StopIT.java</include>
+                                <include>**/SnowflakeSinkServiceV2AvroSchematizationIT.java</include>
+                                <include>**/TopicPartitionChannelIT.java</include>
+                                <include>**/CloseTopicPartitionChannelIT.java</include>
+                                <include>**/StreamingClientProviderIT.java</include>
+                                <include>**/TombstoneRecordIngestionIT.java</include>
+                            </includes>
+                            <skipTests>${skipIntegrationTests}</skipTests>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- Shard 3: Iceberg + Connect cluster tests -->
+        <profile>
+            <id>shard-3</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.22.2</version>
+                        <configuration>
+                            <includes>
+                                <include>**/IcebergIngestionSchemaEvolutionIT.java</include>
+                                <include>**/IcebergIngestionNoSchemaEvolutionIT.java</include>
+                                <include>**/IcebergTableSchemaValidatorIT.java</include>
+                                <include>**/IcebergInitServiceIT.java</include>
+                                <include>**/IcebergIngestionIT.java</include>
+                                <include>**/BaseIcebergIT.java</include>
+                                <include>**/SmtIT.java</include>
+                                <include>**/SnowflakeTelemetryPipeStatusMetricsIT.java</include>
+                            </includes>
+                            <skipTests>${skipIntegrationTests}</skipTests>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary
- Adds 3 Maven shard profiles (`shard-1`, `shard-2`, `shard-3`) to `pom_confluent.xml` for running integration tests in parallel CI jobs
- Used by the private repo's Semaphore CI to split ~22 IT classes across 3 parallel shards, reducing pipeline time from ~1h 48m to ~40 min (55% reduction)
- Existing `aws` / `non-aws` profiles are preserved for local development

## Shard distribution

- **shard-1 (Core Tests)**: Catch-all using `<excludes>` — new IT classes automatically land here. Includes SinkServiceIT, ConnectorIT, SinkTaskIT, SinkTaskProxyIT, ConnectionServiceIT, IngestionServiceIT, InternalStageIT, MetaColumnIT
- **shard-2 (Streaming Tests)**: Explicit `<includes>` for SnowflakeSinkServiceV2IT, TopicPartitionChannelIT, TombstoneRecordIngestionIT, SnowflakeSinkTaskForStreamingIT, CloseTopicPartitionChannelIT, SnowflakeSinkServiceV2AvroSchematizationIT, SnowflakeSinkServiceV2StopIT, StreamingClientProviderIT
- **shard-3 (Iceberg & Connect Cluster Tests)**: Explicit `<includes>` for IcebergIngestionSchemaEvolutionIT, IcebergIngestionNoSchemaEvolutionIT, IcebergTableSchemaValidatorIT, IcebergInitServiceIT, SmtIT, SnowflakeTelemetryPipeStatusMetricsIT

## Test plan
- [x] All 3 shards pass in parallel CI (820 tests total including template ITs)
- [x] Private repo PR: https://github.com/confluentinc/snowflake-kafka-connector-private/pull/337