### PR TITLE
Batch table privilege validation to prevent timeouts

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -28,7 +28,9 @@ import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.streaming.DefaultStreamingConfigValidator;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -366,36 +368,24 @@ public class SnowflakeSinkConnector extends SinkConnector {
 
   private static boolean shouldCheckTablePrivilege(Map<String, String> connectorConfigs) {
     String topicsTablesMap = connectorConfigs.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP);
-    return topicsTablesMap != null && !topicsTablesMap.isEmpty();
+    if (topicsTablesMap == null || topicsTablesMap.isEmpty()) {
+      return false;
+    }
+    String enabled =
+        connectorConfigs.getOrDefault(
+            SnowflakeSinkConnectorConfig.ENABLE_TABLE_PRIVILEGE_VALIDATION,
+            String.valueOf(SnowflakeSinkConnectorConfig.ENABLE_TABLE_PRIVILEGE_VALIDATION_DEFAULT));
+    return Boolean.parseBoolean(enabled);
   }
 
   private static void checkTablePrivilege(
       Map<String, String> topicsTablesMap, SnowflakeConnectionService testConnection) {
-    topicsTablesMap.forEach(
-        (topic, table) -> {
-          try {
-            if (testConnection.tableExist(table)) {
-              LOGGER.info("Table already {} exists, checking if we sufficient privileges", table);
-              testConnection.hasTableRequiredPrivileges(table);
-            }
-          } catch (SnowflakeKafkaConnectorException e) {
-            LOGGER.error(
-                "Validation Error for table {}: msg:{}, errorCode:{}",
-                table,
-                e.getMessage(),
-                e.getCode());
-            if (e.getCode().equals("2001")) {
-              LOGGER.error(table, " Table does not have the required OWNERSHIP privilege");
-            }
-          } catch (Exception e) {
-            LOGGER.error(
-                "Unexpected Exception in validate for table privilege check {}: msg:{},"
-                    + " errorCode:{}",
-                table,
-                e.getMessage(),
-                e);
-          }
-        });
+    Collection<String> uniqueTableNames = new HashSet<>(topicsTablesMap.values());
+    try {
+      testConnection.checkTablesExistenceAndPrivileges(uniqueTableNames);
+    } catch (Exception e) {
+      LOGGER.error("Batch table privilege validation failed: {}", e.getMessage(), e);
+    }
   }
 
   private static boolean isUsingConfigProvider(Map<String, String> connectorConfigs) {

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -294,6 +294,10 @@ public class SnowflakeSinkConnectorConfig {
           "com.snowflake.kafka.connector.records.SnowflakeAvroConverterWithoutSchemaRegistry",
           "com.snowflake.kafka.connector.records.SnowflakeAvroConverter");
 
+  public static final String ENABLE_TABLE_PRIVILEGE_VALIDATION =
+      "enable.table.privilege.validation";
+  public static final boolean ENABLE_TABLE_PRIVILEGE_VALIDATION_DEFAULT = true;
+
   public static final String ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION =
       "enable.task.to.topic.partitions.validation";
   public static final Boolean ENABLE_TASK_TO_TOPIC_PARTITIONS_VALIDATION_DEFAULT = true;

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -658,6 +658,14 @@ public class ConnectorConfigDefinition {
             ConfigDef.Type.LONG,
             TASK_BUFFER_TOTAL_LIMIT_BYTES_DEFAULT,
             ConfigDef.Importance.LOW,
-            "Maximum total buffer size in bytes per task.");
+            "Maximum total buffer size in bytes per task.")
+        .define(
+            ENABLE_TABLE_PRIVILEGE_VALIDATION,
+            ConfigDef.Type.BOOLEAN,
+            ENABLE_TABLE_PRIVILEGE_VALIDATION_DEFAULT,
+            ConfigDef.Importance.LOW,
+            "Enable table privilege validation during connector config validation. "
+                + "Set to false to skip table existence and privilege checks, "
+                + "which can improve validation performance with many table mappings.");
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -4,6 +4,7 @@ import com.snowflake.kafka.connector.internal.streaming.ChannelMigrateOffsetToke
 import com.snowflake.kafka.connector.internal.streaming.schemaevolution.ColumnInfos;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import java.sql.Connection;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -171,6 +172,14 @@ public interface SnowflakeConnectionService {
   void hasSchemaPrivileges(String schemaName, String ingestionMethod);
 
   void hasTableRequiredPrivileges(String tableName);
+
+  /**
+   * Batch check table existence and required privileges for multiple tables. Replaces per-table
+   * queries with batch operations for better performance at scale.
+   *
+   * @param tableNames collection of table names to check
+   */
+  void checkTablesExistenceAndPrivileges(Collection<String> tableNames);
 
   /**
    * drop snowpipe

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -25,11 +25,14 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import net.snowflake.client.jdbc.SnowflakeConnectionV1;
@@ -883,6 +886,119 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
 
     } catch (SQLException e) {
       throw SnowflakeErrors.ERROR_2001.getException(e);
+    }
+  }
+
+  @Override
+  public void checkTablesExistenceAndPrivileges(Collection<String> tableNames) {
+    checkConnection();
+    if (tableNames == null || tableNames.isEmpty()) {
+      return;
+    }
+
+    // Deduplicate and normalize table names to uppercase for matching
+    Set<String> normalizedTargetTables = new HashSet<>();
+    for (String table : tableNames) {
+      normalizedTargetTables.add(table.toUpperCase());
+    }
+
+    // 1. Get current role (single query instead of N queries)
+    String currentRole = getCurrentRole(conn);
+
+    // Resolve the configured database and schema for fully-qualified matching
+    String configuredDb = jdbcProperties.getProperty(InternalUtils.JDBC_DATABASE).toUpperCase();
+    String configuredSchema = jdbcProperties.getProperty(InternalUtils.JDBC_SCHEMA).toUpperCase();
+
+    // 2. Check table existence using SHOW TABLES IN SCHEMA
+    // SHOW TABLES errors if >10,000 rows without LIMIT, so use LIMIT 10000 with pagination
+    Set<String> existingTables = new HashSet<>();
+    try {
+      String lastTableName = null;
+      boolean hasMore = true;
+      while (hasMore) {
+        String query =
+            lastTableName == null
+                ? "SHOW TABLES IN SCHEMA LIMIT 10000"
+                : "SHOW TABLES IN SCHEMA LIMIT 10000 FROM '" + lastTableName + "'";
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery(query);
+        int rowCount = 0;
+        while (rs.next()) {
+          rowCount++;
+          String tableName = rs.getString("name").toUpperCase();
+          lastTableName = tableName;
+          if (normalizedTargetTables.contains(tableName)) {
+            existingTables.add(tableName);
+          }
+        }
+        rs.close();
+        stmt.close();
+        // If we got fewer than 10000 rows, there are no more pages
+        hasMore = rowCount == 10000;
+      }
+    } catch (SQLException e) {
+      LOGGER.warn(
+          "Failed to batch check table existence, skipping table validation: {}", e.getMessage());
+      return;
+    }
+
+    for (String table : normalizedTargetTables) {
+      if (!existingTables.contains(table)) {
+        LOGGER.info("Table {} does not exist, skipping privilege check", table);
+      }
+    }
+
+    if (existingTables.isEmpty()) {
+      LOGGER.info("None of the target tables exist, skipping privilege check");
+      return;
+    }
+
+    // 3. Check privileges using SHOW GRANTS TO ROLE
+    // SHOW GRANTS TO ROLE is account-wide, so we must match the full DB.SCHEMA.TABLE path
+    // against the connector's configured database and schema to avoid cross-schema false positives.
+    String expectedPrefix = configuredDb + "." + configuredSchema + ".";
+    Set<String> tablesWithPrivileges = new HashSet<>();
+    try {
+      Statement stmt = conn.createStatement();
+      ResultSet rs = stmt.executeQuery("SHOW GRANTS TO ROLE " + currentRole);
+      while (rs.next()) {
+        String grantedOn = rs.getString("granted_on");
+        if (!"TABLE".equalsIgnoreCase(grantedOn)) {
+          continue;
+        }
+        String privilege = rs.getString("privilege");
+        if (!privilege.equalsIgnoreCase("OWNERSHIP")
+            && !privilege.equalsIgnoreCase("ALL")
+            && !privilege.equalsIgnoreCase("INSERT")) {
+          continue;
+        }
+        // name column is fully-qualified: DB.SCHEMA.TABLE
+        String fullName = rs.getString("name").toUpperCase();
+        if (!fullName.startsWith(expectedPrefix)) {
+          continue;
+        }
+        String shortName = fullName.substring(expectedPrefix.length());
+        if (existingTables.contains(shortName)) {
+          tablesWithPrivileges.add(shortName);
+        }
+      }
+      rs.close();
+      stmt.close();
+    } catch (SQLException e) {
+      LOGGER.warn(
+          "Failed to batch check table privileges, skipping privilege validation: {}",
+          e.getMessage());
+      return;
+    }
+
+    for (String table : existingTables) {
+      if (tablesWithPrivileges.contains(table)) {
+        LOGGER.info("Table {} has required privileges", table);
+      } else {
+        LOGGER.error(
+            "Table {} exists but is missing required privileges (OWNERSHIP, ALL, or INSERT)",
+            table);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Replace per-table JDBC queries in `validate()` with batch queries (`SHOW TABLES IN SCHEMA`, `SHOW GRANTS TO ROLE`) to go from ~1800 queries to 3 for 600+ table mappings
- Match grants against fully-qualified `DB.SCHEMA.TABLE` names so we don't accidentally match tables from other schemas
- Paginate `SHOW TABLES` to handle schemas with 10K+ tables
- Add `enable.table.privilege.validation` config (default `true`) to skip table checks entirely if needed

## Test plan

- [ ] Compile and format pass
- [ ] Existing unit tests pass
- [ ] Integration test with Snowflake instance for table privilege validation