### PR TITLE
Increase waiting for thread in testThreadLifecycle_PartitionCountIncreases_WarnOnly to 10s

### DIFF
--- a/src/test/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidatorTest.java
@@ -363,7 +363,7 @@ public class TaskToTopicPartitionValidatorTest {
     validator.start();
 
     // Wait for the thread to process at least 2 validation cycles
-    verify(adminClient, timeout(5000).atLeast(2)).describeTopics(anyCollection());
+    verify(adminClient, timeout(10000).atLeast(2)).describeTopics(anyCollection());
 
     // Thread should still be alive since WARN action doesn't stop the thread
     Assertions.assertTrue(


### PR DESCRIPTION
Unit test passing locally 

```
18-03-2026 12:24:23 null-test-task-0-task-to-topic-partitions-validator INFO  TaskToTopicPartitionValidator:46 - [SF_KAFKA_CONNECTOR] Starting TaskToTopicPartitionValidator thread.
18-03-2026 12:24:23 null-test-task-0-task-to-topic-partitions-validator INFO  TaskToTopicPartitionValidator:46 - [SF_KAFKA_CONNECTOR] Total partitions: 10, Max Tasks: 1, Partitions per task: 10, Max allowed partitions per task: 50
18-03-2026 12:24:27 null-test-task-0-task-to-topic-partitions-validator INFO  TaskToTopicPartitionValidator:46 - [SF_KAFKA_CONNECTOR] Total partitions: 100, Max Tasks: 1, Partitions per task: 100, Max allowed partitions per task: 50
18-03-2026 12:24:27 null-test-task-0-task-to-topic-partitions-validator WARN  TaskToTopicPartitionValidator:82 - [SF_KAFKA_CONNECTOR] Partitions per task (100) exceeds maximum allowed partitions (50). Please increase the tasks.max to at least 2, or enable enable.dynamic.flush which would allow 100 partitions per task and ensure the tasks.max is at least 1.
18-03-2026 12:24:27 main INFO  TaskToTopicPartitionValidator:46 - [SF_KAFKA_CONNECTOR] Shutting down TaskToTopicPartitionValidator thread.
18-03-2026 12:24:27 null-test-task-0-task-to-topic-partitions-validator INFO  TaskToTopicPartitionValidator:46 - [SF_KAFKA_CONNECTOR] Closing Kafka Admin Client
18-03-2026 12:24:27 main INFO  TaskToTopicPartitionValidator:46 - [SF_KAFKA_CONNECTOR] Shutting down TaskToTopicPartitionValidator thread.
```

as well as on semaphore 
<img width="520" height="365" alt="Screenshot 2026-03-18 at 12 34 54 PM" src="https://github.com/user-attachments/assets/5cb9b7be-2346-49a9-81d6-8033ce7ec3f0" />
