### PR TITLE
CC-39922 Handle non-existent Kafka topics in the TaskToTopicPartition validator

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
@@ -234,11 +234,6 @@ public class TaskToTopicPartitionValidator extends Thread {
         }
       }
     }
-
-    if (descriptions.isEmpty() && !topicNames.isEmpty()) {
-      LOGGER.warn("Could not describe any topics from the list: {}", topicNames);
-    }
-
     return descriptions;
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/TaskToTopicPartitionValidator.java
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.connect.errors.ConnectException;
 
 /**
@@ -194,16 +195,51 @@ public class TaskToTopicPartitionValidator extends Thread {
 
   private Map<String, TopicDescription> describeTopics(Collection<String> topicNames) {
     LOGGER.debug("Describing topics: {}", topicNames);
+
     try {
       DescribeTopicsResult result = adminClient.describeTopics(topicNames);
       return result.allTopicNames().get();
     } catch (Exception e) {
+      if (e.getCause() instanceof UnknownTopicOrPartitionException) {
+        LOGGER.debug("Some topics don't exist, checking individually");
+        return describeTopicsIndividually(topicNames);
+      }
+
       LOGGER.error("Failed to describe topics: {}", e.getMessage());
       if (e instanceof InterruptedException) {
         Thread.currentThread().interrupt();
       }
       return null;
     }
+  }
+
+  private Map<String, TopicDescription> describeTopicsIndividually(Collection<String> topicNames) {
+    Map<String, TopicDescription> descriptions = new HashMap<>();
+
+    for (String topicName : topicNames) {
+      try {
+        DescribeTopicsResult result =
+            adminClient.describeTopics(Collections.singleton(topicName));
+        Map<String, TopicDescription> singleTopicDesc = result.allTopicNames().get();
+        descriptions.putAll(singleTopicDesc);
+      } catch (Exception e) {
+        if (e.getCause() instanceof UnknownTopicOrPartitionException) {
+          LOGGER.warn("Topic {} does not exist, skipping from validation", topicName);
+        } else if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+          LOGGER.error("Interrupted while describing topic: {}", topicName);
+          return descriptions;
+        } else {
+          LOGGER.warn("Failed to describe topic {}: {}", topicName, e.getMessage());
+        }
+      }
+    }
+
+    if (descriptions.isEmpty() && !topicNames.isEmpty()) {
+      LOGGER.warn("Could not describe any topics from the list: {}", topicNames);
+    }
+
+    return descriptions;
   }
 
   @VisibleForTesting
@@ -228,6 +264,11 @@ public class TaskToTopicPartitionValidator extends Thread {
     Map<String, TopicDescription> descriptions = describeTopics(topics);
     if (descriptions == null) {
       LOGGER.error("Could not describe topics, skipping validating TaskToTopicPartitions.");
+      return;
+    }
+
+    if (descriptions.isEmpty()) {
+      LOGGER.warn("No valid topics found for validation. Topics requested: {}", topics);
       return;
     }
 


### PR DESCRIPTION
**Context**
This is a bug fix. We observed that some connectors running in production still reference topics that have been deleted from Kafka. As a result, the batched describeTopics call fails entirely with an UnknownTopicOrPartitionException. To handle this, we will fall back to querying describeTopics individually per topic and compute the topic partitions while skipping the missing ones.

**Before** 
Validator fails to describe any configured topic.
<img width="1400" height="109" alt="Screenshot 2026-03-18 at 8 20 46 PM" src="https://github.com/user-attachments/assets/b2af0095-1325-464e-bbae-e44877b7a51b" />


**After**
Case 1 – Some topics don’t exist:
The result skips only the missing topics and counts topic partitions for the remaining ones.
<img width="1414" height="203" alt="Screenshot 2026-03-18 at 7 55 36 PM" src="https://github.com/user-attachments/assets/87bc2ad4-d89a-4674-a370-e4c924db6419" />

Case 2 – All topics don’t exist:
Do nothing and issue a warning.
<img width="1401" height="166" alt="Screenshot 2026-03-18 at 8 00 53 PM" src="https://github.com/user-attachments/assets/22eaff07-7d9c-48f2-906e-375e2dc6d7d6" />
