### PR TITLE
[CC-40424] Marked SR related dependencies as provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,6 +444,7 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client-encryption</artifactId>
             <version>${confluent.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->

--- a/pom.xml
+++ b/pom.xml
@@ -444,7 +444,6 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client-encryption</artifactId>
             <version>${confluent.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -619,6 +619,7 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client-encryption</artifactId>
             <version>${confluent.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.confluent/connect-utils -->


### PR DESCRIPTION
## Summary
- Mark `kafka-schema-registry-client-encryption` as provided scope since it is unused in the connector code and is already available in the Kafka Connect runtime.
- This also fixes `kafka-schema-serializer` leaking in as compile scope — it was being pulled in transitively through `kafka-schema-registry-client-encryption` (compile), overriding the provided scope from the `kafka-avro-serializer` path. With this change, it correctly resolves as provided.


Test results
Tested the changes end to end by running a connector with input.data.format as AVRO. Connector works fine and data is landed to the sink.

lcc-devc811oo9q
<img width="1311" height="511" alt="Screenshot 2026-04-28 at 4 24 10 PM" src="https://github.com/user-attachments/assets/a421460a-f9b1-45c8-abc9-d3802e892e6a" />

More over the IT's are also running fine. 
https://semaphore.ci.confluent.io/workflows/0089dd2b-ced3-469c-972f-0fa8fc5dac69/summary?pipeline_id=a598809b-ca8d-4283-b314-24357e25eaf8
