### PR TITLE
CC-39815 Validate RSA private key length

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -293,6 +293,12 @@ public class SnowflakeSinkConnector extends SinkConnector {
           Utils.updateConfigErrorMessage(
               result, Utils.SF_PRIVATE_KEY, " must be a valid PEM RSA private key");
           break;
+        case "0033":
+          Utils.updateConfigErrorMessage(
+              result,
+              Utils.SF_PRIVATE_KEY,
+              " RSA key size is too small. The minimum required key size is 2048 bits.");
+          break;
         default:
           throw e; // Shouldn't reach here, so crash.
       }

--- a/src/main/java/com/snowflake/kafka/connector/internal/EncryptionUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/EncryptionUtils.java
@@ -39,7 +39,11 @@ public class EncryptionUtils {
           new JcaPEMKeyConverter().setProvider(BouncyCastleFipsProvider.PROVIDER_NAME);
       PrivateKeyInfo decryptedPrivateKeyInfo =
           encryptedPrivateKeyInfo.decryptPrivateKeyInfo(pkcs8Prov);
-      return converter.getPrivateKey(decryptedPrivateKeyInfo);
+      PrivateKey privateKey = converter.getPrivateKey(decryptedPrivateKeyInfo);
+      InternalUtils.validateRsaKeySize(privateKey);
+      return privateKey;
+    } catch (SnowflakeKafkaConnectorException e) {
+      throw e;
     } catch (Exception e) {
       throw SnowflakeErrors.ERROR_0018.getException(e);
     }

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -7,6 +7,7 @@ import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
+import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -43,6 +44,7 @@ public class InternalUtils {
   static final String JDBC_QUERY_RESULT_FORMAT = "JDBC_QUERY_RESULT_FORMAT";
   // internal parameters
   static final long MAX_RECOVERY_TIME = 10 * 24 * 3600 * 1000; // 10 days
+  static final int MIN_RSA_KEY_SIZE_BITS = 2048;
 
   private static final KCLogger LOGGER = new KCLogger(InternalUtils.class.getName());
 
@@ -92,9 +94,36 @@ public class InternalUtils {
     try {
       KeyFactory kf = KeyFactory.getInstance("RSA");
       PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(encoded);
-      return kf.generatePrivate(keySpec);
+      PrivateKey privateKey = kf.generatePrivate(keySpec);
+      validateRsaKeySize(privateKey);
+      return privateKey;
+    } catch (SnowflakeKafkaConnectorException e) {
+      throw e;
     } catch (Exception e) {
       throw SnowflakeErrors.ERROR_0002.getException(e);
+    }
+  }
+
+  /**
+   * Validates that the RSA private key meets the minimum size requirement.
+   *
+   * @param privateKey the private key to validate
+   * @throws SnowflakeKafkaConnectorException if the key size is less than 2048 bits
+   */
+  static void validateRsaKeySize(PrivateKey privateKey) {
+    if (privateKey instanceof RSAPrivateKey) {
+      try {
+        RSAPrivateKey rsaKey = (RSAPrivateKey) privateKey;
+        int keySize = rsaKey.getModulus().bitLength();
+        if (keySize < MIN_RSA_KEY_SIZE_BITS) {
+          throw SnowflakeErrors.ERROR_0033.getException(
+              "Current key size: " + keySize + " bits, minimum required: " + MIN_RSA_KEY_SIZE_BITS);
+        }
+      } catch (SnowflakeKafkaConnectorException e) {
+        throw e;
+      } catch (Exception e) {
+        LOGGER.warn("Unable to validate RSA key size: {}", e.getMessage());
+      }
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -144,6 +144,11 @@ public enum SnowflakeErrors {
       "0032",
       "Iceberg table does not exist or is in invalid format",
       "Check Snowflake Kafka Connector docs for details"),
+  ERROR_0033(
+      "0033",
+      "RSA key size is too small",
+      "The RSA private key must be at least 2048 bits. Please generate a new key pair with 2048"
+          + " bits or larger."),
   // Snowflake connection issues 1---
   ERROR_1001(
       "1001",

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
@@ -1,11 +1,17 @@
 package com.snowflake.kafka.connector.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.mock.MockResultSetForSizeTest;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -33,6 +39,37 @@ public class InternalUtilsTest {
     String originalKey = builder.toString();
     // no exception
     InternalUtils.parsePrivateKey(originalKey);
+  }
+
+  @Test
+  public void testPrivateKeyTooSmall() throws Exception {
+    // Generate a 1024-bit RSA key (below the 2048-bit minimum)
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+    keyGen.initialize(1024);
+    KeyPair keyPair = keyGen.generateKeyPair();
+    PrivateKey smallKey = keyPair.getPrivate();
+    String smallKeyPem = Base64.getEncoder().encodeToString(smallKey.getEncoded());
+
+    // Should throw ERROR_0033 for key size too small
+    SnowflakeKafkaConnectorException exception =
+        assertThrows(
+            SnowflakeKafkaConnectorException.class,
+            () -> InternalUtils.parsePrivateKey(smallKeyPem));
+    assertTrue(exception.checkErrorCode(SnowflakeErrors.ERROR_0033));
+    assertTrue(
+        exception.getMessage().contains("Current key size: 1024 bits, minimum required: 2048"));
+  }
+
+  @Test
+  public void testValidateRsaKeySize_ValidKey() throws Exception {
+    // Generate a 2048-bit RSA key (meets minimum requirement)
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+    keyGen.initialize(2048);
+    KeyPair keyPair = keyGen.generateKeyPair();
+    PrivateKey validKey = keyPair.getPrivate();
+
+    // Should not throw any exception
+    InternalUtils.validateRsaKeySize(validKey);
   }
 
   @Test


### PR DESCRIPTION
- Validate RSA private key size during connector configuration to ensure it meets Snowflake's minimum requirement of 2048 bits
- Provide a clear, actionable error message when the key size is too small, instead of failing deep in the JDBC driver with a cryptic exception

Test Plan

- [x]  Run unit tests: mvn test -Dtest=InternalUtilsTest -Dgpg.skip=true
- [x] Verify that a 1024-bit RSA key is rejected with error code 0033
- [x] Verify that a 2048-bit RSA key is accepted without errors
- [x] Verify that encrypted private keys with insufficient key size are also rejected
- [x] Run integration tests

1024-bit RSA key rejected
<img width="564" height="605" alt="Screenshot 2026-04-09 at 3 44 59 PM" src="https://github.com/user-attachments/assets/7d1f9dbe-43cf-4d85-bdc2-1d52aa9c1f11" />

1024-bit RSA encrypted key rejected
<img width="585" height="603" alt="Screenshot 2026-04-09 at 3 47 43 PM" src="https://github.com/user-attachments/assets/527df92d-d2e5-44dd-bce1-cdf19c08fe50" />

Connector running with 1024-bit RSA key if somehow validation gets skipped. 
<img width="1068" height="322" alt="Screenshot 2026-04-09 at 2 28 12 PM" src="https://github.com/user-attachments/assets/d1fcfcb5-725e-4b6f-8e42-72dbafe0b814" />

When created via CLI 
<img width="842" height="259" alt="Screenshot 2026-04-09 at 4 01 56 PM" src="https://github.com/user-attachments/assets/ee373524-7232-4006-bea5-414073bdd651" />

Integration test results -> https://semaphore.ci.confluent.io/workflows/036305cc-52a0-4314-a047-06731997c036/summary?pipeline_id=41ff5e35-d520-4c7f-971e-f9bc520d317d
