### PR TITLE
Bump org.slf4j:slf4j-api from 1.7.25 to 2.0.16 (#1024)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <iceberg.version>1.6.1</iceberg.version>
         <jackson.version>2.18.2</jackson.version>
         <commons-compress.version>1.27.1</commons-compress.version>
+        <slf4j-api.version>2.0.16</slf4j-api.version>
     </properties>
 
 
@@ -517,12 +518,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>${slf4j-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.25</version>
+            <version>${slf4j-api.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -69,6 +69,7 @@
         <iceberg.version>1.6.1</iceberg.version>
         <jackson.version>2.18.2</jackson.version>
         <commons-compress.version>1.27.1</commons-compress.version>
+        <slf4j-api.version>2.0.16</slf4j-api.version>
     </properties>
 
 
@@ -688,12 +689,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>${slf4j-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.25</version>
+            <version>${slf4j-api.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Cherry pick https://github.com/snowflakedb/snowflake-kafka-connector/commit/ccd47202a524f63c4dd89155145cd747d367d49c

Semaphore job is currently failing https://semaphore.ci.confluent.io/workflows/21fde564-635f-49f9-aab6-1a4caf0c2e71?pipeline_id=707f2da2-01a8-4478-becc-7824f0254042
passing with the fix https://semaphore.ci.confluent.io/workflows/3619d30a-b49c-402e-97f2-2293e6f2a797/summary?pipeline_id=2d03bb4c-6760-4d9e-83f3-db278d404a19