### PR TITLE
CC-40192: Return field level errors in validate instead of 500 Internal Server Error on OAuth token fetch failure 

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -297,6 +297,19 @@ public class SnowflakeSinkConnector extends SinkConnector {
               Utils.SF_PRIVATE_KEY,
               " RSA key size is too small. The minimum required key size is 2048 bits.");
           break;
+        case "1004":
+          // OAuth token fetch failed (expired/invalid refresh token, wrong
+          // client id/secret, unreachable token endpoint, etc.). Surface as
+          // field-level validation errors on the OAuth fields rather than a 500.
+          String oauthErrorString =
+              String.format(
+                  ": Failed to fetch OAuth access token from Snowflake. %s",
+                  e.getExceptionUserMessage());
+          Utils.updateConfigErrorMessage(result, Utils.SF_OAUTH_CLIENT_ID, oauthErrorString);
+          Utils.updateConfigErrorMessage(result, Utils.SF_OAUTH_CLIENT_SECRET, oauthErrorString);
+          Utils.updateConfigErrorMessage(result, Utils.SF_OAUTH_REFRESH_TOKEN, oauthErrorString);
+          Utils.updateConfigErrorMessage(result, Utils.SF_OAUTH_TOKEN_ENDPOINT, oauthErrorString);
+          break;
         default:
           throw e; // Shouldn't reach here, so crash.
       }

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -25,6 +25,7 @@ import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.OAuthConstants;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeInternalOperations;
+import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import java.io.BufferedReader;
 import java.io.File;
@@ -57,8 +58,10 @@ import net.snowflake.client.jdbc.internal.apache.http.entity.StringEntity;
 import net.snowflake.client.jdbc.internal.apache.http.impl.client.CloseableHttpClient;
 import net.snowflake.client.jdbc.internal.apache.http.impl.client.HttpClientBuilder;
 import net.snowflake.client.jdbc.internal.apache.http.util.EntityUtils;
+import net.snowflake.client.jdbc.internal.google.gson.JsonElement;
 import net.snowflake.client.jdbc.internal.google.gson.JsonObject;
 import net.snowflake.client.jdbc.internal.google.gson.JsonParser;
+import net.snowflake.client.jdbc.internal.google.gson.JsonSyntaxException;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.common.utils.ThreadUtils;
@@ -797,10 +800,11 @@ public class Utils {
               SnowflakeInternalOperations.FETCH_OAUTH_TOKEN,
               () -> {
                 try (CloseableHttpResponse httpResponse = client.execute(post)) {
+                  int statusCode = httpResponse.getStatusLine().getStatusCode();
                   String respBodyString = EntityUtils.toString(httpResponse.getEntity());
-                  JsonObject respBody = JsonParser.parseString(respBodyString).getAsJsonObject();
-                  // Trim surrounding quotation marks
-                  return respBody.get(tokenType).toString().replaceAll("^\"|\"$", "");
+                  return parseOAuthTokenResponse(tokenType, statusCode, respBodyString);
+                } catch (SnowflakeKafkaConnectorException e) {
+                  throw e;
                 } catch (Exception e) {
                   throw SnowflakeErrors.ERROR_1004.getException(e);
                 }
@@ -809,6 +813,61 @@ public class Utils {
     } catch (Exception e) {
       throw SnowflakeErrors.ERROR_1004.getException(e);
     }
+  }
+
+  /**
+   * Parse the OAuth authorization server response body and extract the token of the given type.
+   * Throws a descriptive {@link SnowflakeKafkaConnectorException} with code 1004 when the response
+   * is not valid JSON or does not contain the expected token field (e.g. when the server returned
+   * an RFC 6749 error response). Visible for testing.
+   */
+  static String parseOAuthTokenResponse(String tokenType, int statusCode, String respBodyString) {
+    JsonObject respBody;
+    try {
+      respBody = JsonParser.parseString(respBodyString).getAsJsonObject();
+    } catch (IllegalStateException | JsonSyntaxException parseEx) {
+      throw SnowflakeErrors.ERROR_1004.getException(
+          "OAuth authorization server returned non-JSON response (HTTP " + statusCode + ").");
+    }
+    JsonElement tokenElement = respBody.get(tokenType);
+    if (tokenElement == null || tokenElement.isJsonNull()) {
+      throw SnowflakeErrors.ERROR_1004.getException(
+          buildOAuthErrorMessage(tokenType, statusCode, respBody));
+    }
+    // Trim surrounding quotation marks
+    return tokenElement.toString().replaceAll("^\"|\"$", "");
+  }
+
+  /**
+   * Build a descriptive message for the case where the OAuth authorization server response is
+   * missing the expected token field. Uses the standard RFC 6749 fields (error, error_description)
+   * when present so the caller gets actionable information instead of an NPE.
+   */
+  private static String buildOAuthErrorMessage(
+      String tokenType, int statusCode, JsonObject respBody) {
+    String oauthError = readStringField(respBody, "error");
+    String oauthErrorDescription = readStringField(respBody, "error_description");
+    StringBuilder message =
+        new StringBuilder("OAuth authorization server response did not include ")
+            .append(tokenType)
+            .append(" (HTTP ")
+            .append(statusCode)
+            .append(").");
+    if (oauthError != null) {
+      message.append(" error=").append(oauthError).append(".");
+    }
+    if (oauthErrorDescription != null) {
+      message.append(" error_description=").append(oauthErrorDescription).append(".");
+    }
+    return message.toString();
+  }
+
+  private static String readStringField(JsonObject obj, String name) {
+    JsonElement element = obj.get(name);
+    if (element == null || element.isJsonNull() || !element.isJsonPrimitive()) {
+      return null;
+    }
+    return element.getAsString();
   }
 
   /**

--- a/src/test/java/com/snowflake/kafka/connector/UtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/UtilsTest.java
@@ -1,6 +1,7 @@
 package com.snowflake.kafka.connector;
 
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
+import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.SnowflakeURL;
 import com.snowflake.kafka.connector.internal.TestUtils;
 import java.util.HashMap;
@@ -328,6 +329,64 @@ public class UtilsTest {
       TestUtils.assertError(
           SnowflakeErrors.ERROR_1004,
           () -> Utils.getSnowflakeOAuthAccessToken(url, "INVALID", "INVALID", "INVALID"));
+    }
+  }
+
+  @Test
+  public void testParseOAuthTokenResponseSuccess() {
+    String body = "{\"access_token\":\"abc123\",\"token_type\":\"Bearer\"}";
+    String token = Utils.parseOAuthTokenResponse("access_token", 200, body);
+    Assert.assertEquals("abc123", token);
+  }
+
+  // Regression for CC-40192: a Snowflake OAuth error response (missing
+  // access_token) used to trigger a NullPointerException because the code
+  // called .toString() on a null JsonElement. The validate endpoint should
+  // now surface this as ERROR_1004 with a meaningful message.
+  @Test
+  public void testParseOAuthTokenResponseMissingTokenThrows1004() {
+    String body =
+        "{\"error\":\"invalid_grant\",\"error_description\":\"refresh token is invalid\"}";
+    try {
+      Utils.parseOAuthTokenResponse("access_token", 400, body);
+      Assert.fail("Expected SnowflakeKafkaConnectorException");
+    } catch (SnowflakeKafkaConnectorException e) {
+      Assert.assertEquals("1004", e.getCode());
+      Assert.assertTrue(
+          "error message should mention missing token field, but was: " + e.getMessage(),
+          e.getMessage().contains("access_token"));
+      Assert.assertTrue(
+          "error message should include OAuth error code from response, but was: " + e.getMessage(),
+          e.getMessage().contains("invalid_grant"));
+      Assert.assertTrue(
+          "error message should include the HTTP status code, but was: " + e.getMessage(),
+          e.getMessage().contains("400"));
+    }
+  }
+
+  @Test
+  public void testParseOAuthTokenResponseNullTokenFieldThrows1004() {
+    // JSON where the token field is explicitly null — previously caused NPE.
+    String body = "{\"access_token\":null}";
+    try {
+      Utils.parseOAuthTokenResponse("access_token", 200, body);
+      Assert.fail("Expected SnowflakeKafkaConnectorException");
+    } catch (SnowflakeKafkaConnectorException e) {
+      Assert.assertEquals("1004", e.getCode());
+    }
+  }
+
+  @Test
+  public void testParseOAuthTokenResponseNonJsonThrows1004() {
+    String body = "Service Unavailable";
+    try {
+      Utils.parseOAuthTokenResponse("access_token", 503, body);
+      Assert.fail("Expected SnowflakeKafkaConnectorException");
+    } catch (SnowflakeKafkaConnectorException e) {
+      Assert.assertEquals("1004", e.getCode());
+      Assert.assertTrue(
+          "error message should mention non-JSON response, but was: " + e.getMessage(),
+          e.getMessage().contains("non-JSON"));
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes [CC-40192](https://confluentinc.atlassian.net/browse/CC-40192). The SnowflakeSink connector's `/connector-plugins/SnowflakeSink/config/validate` endpoint returned **HTTP 500 with a NullPointerException** when the Snowflake OAuth token fetch failed (expired/revoked refresh token, disabled security integration, etc.). This change makes the validate endpoint return a **proper config-validation response with field-level errors on the OAuth fields**, so the operator can surface an actionable error to the customer instead of a generic 500.

## Root cause

In `Utils.getSnowflakeOAuthToken` (`Utils.java:803` on `3.1.x`), the code unconditionally called `.toString()` on the response body's token field:

```java
return respBody.get(tokenType).toString().replaceAll("^\"|\"$", "");
```

When Snowflake's OAuth token endpoint returns an RFC 6749 error response (e.g. `{"error":"invalid_grant","error_description":"..."}` or `{"error":"invalid_client",...}`), there is **no `access_token` field** in the body. `respBody.get("access_token")` returns `null`, and `.toString()` on null throws `NullPointerException`. The NPE was wrapped as `SnowflakeKafkaConnectorException` (code 1004) but bubbled up to `SnowflakeSinkConnector.validate()`, whose switch had no case for `"1004"` - so it fell through `default: throw e` and the framework surfaced an HTTP 500 from the validate endpoint.

The cc-connect operator then logs the customer-impacting error (literally observed in production for the original ticket and reproduced 1:1 in devel canary-4):

```
could not validate connector lcc-..., PUT request failed to endpoint
http://connect.pcc-....svc.cluster.local:8083/connector-plugins/SnowflakeSink/config/validate?extra_fields=configs/metadata,
... reason=bad response code: 500 Internal Server Error,
error response - {"error_code":500,"message":"...Cannot invoke
\"net.snowflake.client.jdbc.internal.google.gson.JsonElement.toString()\"
because the return value of
\"net.snowflake.client.jdbc.internal.google.gson.JsonObject.get(String)\"
is null..."}
```

## Changes

**`Utils.java`** - extract response parsing into a new `parseOAuthTokenResponse(tokenType, statusCode, respBodyString)` (package-private, testable). The new method:

- guards the JSON parse itself (catches `IllegalStateException` / `JsonSyntaxException`) so non-JSON responses produce a clean `ERROR_1004` instead of an opaque exception;
- explicitly null-checks `respBody.get(tokenType)` (and `tokenElement.isJsonNull()`) before calling `.toString()` - this is the actual NPE fix;
- when the token is missing, throws `ERROR_1004` with a descriptive message built from the RFC 6749 `error` and `error_description` fields, so the caller sees `OAuth authorization server response did not include access_token (HTTP 400). error=invalid_grant. error_description=...`;
- preserves existing retry behavior via `InternalUtils.backoffAndRetry`. The outer lambda now distinguishes `SnowflakeKafkaConnectorException` (rethrown as-is to keep the descriptive message) from generic exceptions (still wrapped in `ERROR_1004`).

**`SnowflakeSinkConnector.java`** - handle code `"1004"` in `validate()`'s switch alongside the existing `0026` / `0027` / `0028` / `0029` OAuth cases. The new arm attaches a field-level error to the four OAuth config keys:

- `snowflake.oauth.client.id`
- `snowflake.oauth.client.secret`
- `snowflake.oauth.refresh.token`
- `snowflake.oauth.token.endpoint`

The field error includes Snowflake's own RFC 6749 message (via `e.getExceptionUserMessage()`), so the customer sees exactly what Snowflake's authorization server reported.

**`UtilsTest.java`** - four new unit tests against `parseOAuthTokenResponse`:

- happy path (`access_token` present);
- **missing `access_token` field** (regression test for the original NPE);
- explicitly `null` token field (`{"access_token":null}`);
- non-JSON response body.

All assert `ERROR_1004` with a meaningful message; none NPE.



## Test plan



### End-to-end repro in devel
Built a dirty `cc-connect` image from this branch (`v0.3247.0-4902d088-dirty-sangeet259`) and deployed to `developer-canary-3`. Ran the same scenario on:

- **Canary-4** (no fix, base image `v0.3235.0-9a71969e-dirty-yashisrivastava`) - control.
- **Canary-3** (this PR's image) - patched.

Same conditions on both: created a SnowflakeSink connector with OAuth credentials backed by the same Snowflake security integration `SF_OAUTH_SECURITY_INTEGRATION`, then disabled the integration in Snowflake (`ALTER SECURITY INTEGRATION ... SET ENABLED = FALSE`), then either edited the connector config or simply waited for the operator's periodic ~3-min validate cycle.

| | **Canary-4 (no fix)** | **Canary-3 (this PR)** |
|---|---|---|
| Validate endpoint HTTP status | **500** Internal Server Error | **200** OK |
| `ConnectExceptionMapper` `Uncaught exception in REST call` | present | absent |
| `Cannot invoke "JsonElement.toString()" ... JsonObject.get(String) is null` NPE | present at `Utils.java:803` | absent |
| Operator log on validate response | `error level` - `Could not validate connector configs ... bad response code: 500 Internal Server Error` | `info level` - `Validated connector configs and found 3 errors.` |
| Operator state classification | retries 5 times → `exhausted_retries=true` → `SYSTEM_ERROR` (~5 min to FAILED) | immediately `USER_ACTIONABLE_ERROR` (~30s) |
| Connector's `Trace` (visible to customer in CLI / API) | **empty**, then `"The connector failed due to an unexpected error. Contact our Support team to quickly resolve this issue."` | populated with per-field errors: `"Failed to fetch OAuth access token from Snowflake. ... OAuth authorization server response did not include access_token (HTTP 400). error=invalid_client."` (one entry each for `oauth.client.id`, `oauth.client.secret`, `oauth.refresh.token`, `oauth.token.endpoint`) |
| Stack frame at top of NPE | `Utils.lambda$getSnowflakeOAuthToken$1(Utils.java:803)` (unfixed `.toString()` on null) | `Utils.parseOAuthTokenResponse(Utils.java:834)` (new null-checking method) |
| Auto-recovery when integration is re-enabled | recovers via operator's ~3-min poll cycle (with a transient `SYSTEM_ERROR` flicker - separate operator-side issue) | recovers via operator's ~3-min poll cycle, same flicker |


### Sample log evidence
On canary-3 (with fix), the operator's `logs.operator` index shows at the moment of failure:

```
2026-04-29T08:40:23.960Z  status_manager.go:774
"Failed to update connector before starting the connector: validatedConfigs. ErrorCount=3"
errors[oauth.client.id]    = "Failed to fetch OAuth access token from Snowflake. ... OAuth authorization server response did not include access_token (HTTP 400). error=invalid_client."
errors[oauth.client.secret] = (same)
errors[oauth.refresh.token] = (same)
```

vs canary-4 (no fix) at the equivalent moment:

```
2026-04-29T07:38:22.319Z  connect_controller.go:448
"Could not fully allocate connector=lcc-..."
err = "could not validate connector ..., PUT request failed to endpoint ... /config/validate ..., reason=bad response code: 500 Internal Server Error,
error response - {"error_code":500,"message":"...Cannot invoke \"...JsonElement.toString()\"
because the return value of \"...JsonObject.get(String)\" is null..."}"
```

You can see in the CCloud UI Console:

<img width="1127" height="1211" alt="image" src="https://github.com/user-attachments/assets/82162b0c-009d-48ed-97ac-5c3e68bddd9f" />

Connector is in failed state with the field level OAuth errors populated.


<img width="1162" height="322" alt="image" src="https://github.com/user-attachments/assets/35249d4f-4387-4a22-a525-67d676619270" />
And the error is correctly being shown as user error.


[CC-40192]: https://confluentinc.atlassian.net/browse/CC-40192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



### UTs and ITs

These are run as part of this PR's [workflow](https://github.com/confluentinc/snowflake-kafka-connector-private/pull/356)

<img width="849" height="496" alt="image" src="https://github.com/user-attachments/assets/060805e4-4152-4242-bab6-4a4c7a98ba34" />
