### PR TITLE
Marked `org.apache.avro:avro` as provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,7 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>1.11.4</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Recently we removed SR related dependencies but some AVRO related dependencies were left which can cause linkage error during runtime. reference - https://confluentinc.atlassian.net/wiki/spaces/~7120200dd4a330abdf4b08929e63c9238d04d7/pages/5596285616/CC-41475+Incomplete+SR+dep+exclusion+causes+AvroData+LinkageError

Remove the AVRO related dependencies as they will be present during runtime