### PR TITLE
Fixes to run on Confluent Cloud

### DIFF
--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -75,7 +75,7 @@
         <commons-compress.version>1.27.1</commons-compress.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <snowflake-jdbc.version>3.26.1-1</snowflake-jdbc.version>
-        <snowflake-ingest-sdk.version>4.3.2-5</snowflake-ingest-sdk.version>
+        <snowflake-ingest-sdk.version>4.3.2-6</snowflake-ingest-sdk.version>
         <slf4j-api.version>2.0.17</slf4j-api.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
     </properties>

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -234,6 +234,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
           SnowflakeConnectionServiceFactory.builder()
               .setNetworkTimeout(VALIDATION_NETWORK_TIMEOUT_IN_MS)
               .setLoginTimeOut(VALIDATION_LOGIN_TIMEOUT_IN_SEC)
+              .setValidationMode(true)
               .setProperties(connectorConfigs)
               .build();
 

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -286,6 +286,17 @@ public class SnowflakeSinkConnectorConfig {
           + " for incremental offsets (might contain gaps) and might signal false positives in case"
           + " of SMT. Can only be set if Streaming Snowpipe is enabled";
 
+  public static final String ENABLE_STREAMING_INFINITY_HANDLING_CONFIG =
+      "snowflake.streaming.enable.handling.infinity.values";
+  public static final String ENABLE_STREAMING_INFINITY_HANDLING_DISPLAY =
+      "Enable handling infinity values";
+  public static final boolean ENABLE_STREAMING_INFINITY_HANDLING_DEFAULT = false;
+  public static final String ENABLE_STREAMING_INFINITY_HANDLING_DOC =
+      "Whether to enable correct handling for infinity and negative infinity values in float/double"
+          + " fields when using Snowpipe Streaming. When enabled, infinity values will be correctly"
+          + " ingested as 'Inf' or '-Inf'. When disabled, infinity values will be treated as 'NaN'"
+          + " for backward compatibility. Can only be set if Streaming Snowpipe is enabled";
+
   public static final String ENABLE_TASK_FAIL_ON_AUTHORIZATION_ERRORS =
       "enable.task.fail.on.authorization.errors";
   public static final boolean ENABLE_TASK_FAIL_ON_AUTHORIZATION_ERRORS_DEFAULT = false;

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -496,6 +496,19 @@ public class Utils {
 
   /**
    * @param config config with applied default values
+   * @return true when streaming infinity handling is enabled.
+   */
+  public static boolean isStreamingInfinityHandlingEnabled(Map<String, String> config) {
+    String value =
+        config.get(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_INFINITY_HANDLING_CONFIG);
+    if (value == null) {
+      return SnowflakeSinkConnectorConfig.ENABLE_STREAMING_INFINITY_HANDLING_DEFAULT;
+    }
+    return Boolean.parseBoolean(value);
+  }
+
+  /**
+   * @param config config with applied default values
    * @return role specified in rhe config
    */
   public static String role(Map<String, String> config) {

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -668,6 +668,16 @@ public class ConnectorConfigDefinition {
             CONNECTOR_CONFIG_DOC,
             12,
             ConfigDef.Width.NONE,
-            SNOWPIPE_STREAMING_CHANNEL_NAME_INCLUDE_CONNECTOR_NAME_DISPLAY);
+            SNOWPIPE_STREAMING_CHANNEL_NAME_INCLUDE_CONNECTOR_NAME_DISPLAY)
+        .define(
+            ENABLE_STREAMING_INFINITY_HANDLING_CONFIG,
+            ConfigDef.Type.BOOLEAN,
+            ENABLE_STREAMING_INFINITY_HANDLING_DEFAULT,
+            ConfigDef.Importance.LOW,
+            ENABLE_STREAMING_INFINITY_HANDLING_DOC,
+            CONNECTOR_CONFIG_DOC,
+            13,
+            ConfigDef.Width.NONE,
+            ENABLE_STREAMING_INFINITY_HANDLING_DISPLAY);
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -313,9 +313,10 @@ public class InternalUtils {
 
     // Set additional HTTP client timeouts for validation mode to ensure faster failure
     if (isValidationMode) {
-      properties.put(JDBC_HTTP_CLIENT_CONNECTION_TIMEOUT, "60000"); // 60 seconds in milliseconds
-      properties.put(JDBC_HTTP_CLIENT_SOCKET_TIMEOUT, "60000"); // 60 seconds in milliseconds
-      properties.put(JDBC_RETRY_TIMEOUT, "30"); // 30 seconds
+      properties.put(JDBC_HTTP_CLIENT_CONNECTION_TIMEOUT, "45000"); // 45 seconds in milliseconds
+      properties.put(JDBC_HTTP_CLIENT_SOCKET_TIMEOUT, "45000"); // 45 seconds in milliseconds
+      properties.put(JDBC_RETRY_TIMEOUT, "10");
+      properties.put("maxHttpRetries", "1");
     }
 
     // put values for optional parameters

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -39,6 +39,12 @@ public class InternalUtils {
 
   static final String JDBC_LOGIN_TIMEOUT = "loginTimeout";
 
+  // HTTP client timeouts for validation mode (in milliseconds)
+  static final String JDBC_HTTP_CLIENT_CONNECTION_TIMEOUT = "HTTP_CLIENT_CONNECTION_TIMEOUT";
+  static final String JDBC_HTTP_CLIENT_SOCKET_TIMEOUT = "HTTP_CLIENT_SOCKET_TIMEOUT";
+  // Retry timeout in seconds
+  static final String JDBC_RETRY_TIMEOUT = "retryTimeout";
+
   static final String JDBC_AUTHENTICATOR = SFSessionProperty.AUTHENTICATOR.getPropertyKey();
   static final String JDBC_TOKEN = SFSessionProperty.TOKEN.getPropertyKey();
   static final String JDBC_QUERY_RESULT_FORMAT = "JDBC_QUERY_RESULT_FORMAT";
@@ -158,7 +164,7 @@ public class InternalUtils {
   static Properties createProperties(
       Map<String, String> conf, int networkTimeout, int loginTimeout, SnowflakeURL url) {
     return createProperties(
-        conf, networkTimeout, loginTimeout, url, IngestionMethodConfig.SNOWPIPE);
+        conf, networkTimeout, loginTimeout, url, IngestionMethodConfig.SNOWPIPE, false);
   }
 
   /**
@@ -175,6 +181,27 @@ public class InternalUtils {
       int loginTimeout,
       SnowflakeURL url,
       IngestionMethodConfig ingestionMethodConfig) {
+    return createProperties(
+        conf, networkTimeout, loginTimeout, url, ingestionMethodConfig, false);
+  }
+
+  /**
+   * create a properties for snowflake connection
+   *
+   * @param conf a map contains all parameters
+   * @param url target server url
+   * @param ingestionMethodConfig which ingestion method is provided.
+   * @param isValidationMode if true, sets additional HTTP client timeouts for faster failure during
+   *     validation
+   * @return a Properties instance
+   */
+  static Properties createProperties(
+      Map<String, String> conf,
+      int networkTimeout,
+      int loginTimeout,
+      SnowflakeURL url,
+      IngestionMethodConfig ingestionMethodConfig,
+      boolean isValidationMode) {
     Properties properties = new Properties();
 
     // add application parameter to identify connector created from CONFLUENT_CLOUD
@@ -282,6 +309,13 @@ public class InternalUtils {
 
     if (loginTimeout != 0) {
       properties.put(JDBC_LOGIN_TIMEOUT, loginTimeout);
+    }
+
+    // Set additional HTTP client timeouts for validation mode to ensure faster failure
+    if (isValidationMode) {
+      properties.put(JDBC_HTTP_CLIENT_CONNECTION_TIMEOUT, "60000"); // 60 seconds in milliseconds
+      properties.put(JDBC_HTTP_CLIENT_SOCKET_TIMEOUT, "60000"); // 60 seconds in milliseconds
+      properties.put(JDBC_RETRY_TIMEOUT, "30"); // 30 seconds
     }
 
     // put values for optional parameters

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
@@ -28,6 +28,10 @@ public class SnowflakeConnectionServiceFactory {
     // https://docs.snowflake.com/en/user-guide/jdbc-parameters.html#logintimeout
     private int loginTimeOut = 60;
 
+    // Flag to indicate if this connection is for validation purposes
+    // When true, additional HTTP client timeouts are set for faster failure
+    private boolean isValidationMode = false;
+
     // whether kafka is hosted on premise or on confluent cloud.
     // This info is provided in the connector configuration
     // This property will be appeneded to user agent while calling snowpipe API in http request
@@ -73,6 +77,11 @@ public class SnowflakeConnectionServiceFactory {
       return this;
     }
 
+    public SnowflakeConnectionServiceBuilder setValidationMode(boolean isValidationMode) {
+      this.isValidationMode = isValidationMode;
+      return this;
+    }
+
     public SnowflakeConnectionServiceBuilder setProperties(Map<String, String> conf) {
       if (!conf.containsKey(Utils.SF_URL)) {
         throw SnowflakeErrors.ERROR_0017.getException();
@@ -86,7 +95,12 @@ public class SnowflakeConnectionServiceFactory {
       Properties proxyProperties = InternalUtils.generateProxyParametersIfRequired(conf);
       Properties connectionProperties =
           InternalUtils.createProperties(
-              conf, this.networkTimeOut, this.loginTimeOut, this.url, ingestionMethodConfig);
+              conf,
+              this.networkTimeOut,
+              this.loginTimeOut,
+              this.url,
+              ingestionMethodConfig,
+              this.isValidationMode);
       Properties jdbcPropertiesMap = InternalUtils.parseJdbcPropertiesMap(conf);
       this.jdbcProperties =
           JdbcProperties.create(connectionProperties, proxyProperties, jdbcPropertiesMap);

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -175,7 +175,9 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
         sinkTaskContext,
         conn,
         RecordServiceFactory.createRecordService(
-            false, Utils.isSchematizationEnabled(sfConnectorConfig)),
+            false,
+            Utils.isSchematizationEnabled(sfConnectorConfig),
+            Utils.isStreamingInfinityHandlingEnabled(sfConnectorConfig)),
         telemetryService,
         false,
         null,

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/OpenChannelRetryPolicy.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/OpenChannelRetryPolicy.java
@@ -34,6 +34,9 @@ class OpenChannelRetryPolicy {
   /** Random jitter added to retry delays to prevent thundering herd. */
   private static final Duration JITTER_DURATION = Duration.ofMillis(200);
 
+  /** Maximum number of retry attempts before giving up. */
+  private static final int MAX_ATTEMPTS = 10;
+
   /**
    * Executes the provided channel opening action with retry handling.
    *
@@ -52,7 +55,7 @@ class OpenChannelRetryPolicy {
             .handleIf(OpenChannelRetryPolicy::isRetryableError)
             .withBackoff(INITIAL_DELAY, MAX_DELAY, BACKOFF_MULTIPLIER)
             .withJitter(JITTER_DURATION)
-            .withMaxAttempts(-1)
+            .withMaxAttempts(MAX_ATTEMPTS)
             .onRetry(
                 event ->
                     LOGGER.warn(

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -141,9 +141,10 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     this.conn = conn;
     this.telemetryService = conn.getTelemetryClient();
     boolean schematizationEnabled = Utils.isSchematizationEnabled(connectorConfig);
+    boolean infinityHandlingEnabled = Utils.isStreamingInfinityHandlingEnabled(connectorConfig);
     this.recordService =
         RecordServiceFactory.createRecordService(
-            Utils.isIcebergEnabled(connectorConfig), schematizationEnabled);
+            Utils.isIcebergEnabled(connectorConfig), schematizationEnabled, infinityHandlingEnabled);
     this.icebergTableSchemaValidator = new IcebergTableSchemaValidator(conn);
     this.icebergInitService = new IcebergInitService(conn);
     this.schemaEvolutionService =

--- a/src/main/java/com/snowflake/kafka/connector/records/IcebergTableStreamingRecordMapper.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/IcebergTableStreamingRecordMapper.java
@@ -18,9 +18,13 @@ class IcebergTableStreamingRecordMapper extends StreamingRecordMapper {
   private static final TypeReference<Map<String, Object>> OBJECTS_MAP_TYPE_REFERENCE =
       new TypeReference<Map<String, Object>>() {};
 
-  public IcebergTableStreamingRecordMapper(
-      ObjectMapper objectMapper, boolean schematizationEnabled) {
+  public IcebergTableStreamingRecordMapper(ObjectMapper objectMapper, boolean schematizationEnabled) {
     super(objectMapper, schematizationEnabled);
+  }
+
+  public IcebergTableStreamingRecordMapper(
+      ObjectMapper objectMapper, boolean schematizationEnabled, boolean enableInfinitySupport) {
+    super(objectMapper, schematizationEnabled, enableInfinitySupport);
   }
 
   @Override

--- a/src/main/java/com/snowflake/kafka/connector/records/RecordServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordServiceFactory.java
@@ -1,17 +1,45 @@
 package com.snowflake.kafka.connector.records;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 
 public class RecordServiceFactory {
+
+  /**
+   * Creates a RecordService with default infinity handling (disabled).
+   *
+   * @param isIcebergEnabled whether Iceberg mode is enabled
+   * @param enableSchematization whether schematization is enabled
+   * @return RecordService instance
+   */
   public static RecordService createRecordService(
       boolean isIcebergEnabled, boolean enableSchematization) {
+    return createRecordService(
+        isIcebergEnabled,
+        enableSchematization,
+        SnowflakeSinkConnectorConfig.ENABLE_STREAMING_INFINITY_HANDLING_DEFAULT);
+  }
+
+  /**
+   * Creates a RecordService with explicit infinity handling configuration.
+   *
+   * @param isIcebergEnabled whether Iceberg mode is enabled
+   * @param enableSchematization whether schematization is enabled
+   * @param enableInfinityHandling whether infinity handling is enabled
+   * @return RecordService instance
+   */
+  public static RecordService createRecordService(
+      boolean isIcebergEnabled, boolean enableSchematization, boolean enableInfinityHandling) {
     ObjectMapper objectMapper = new ObjectMapper();
     if (isIcebergEnabled) {
       return new RecordService(
-          new IcebergTableStreamingRecordMapper(objectMapper, enableSchematization), objectMapper);
+          new IcebergTableStreamingRecordMapper(
+              objectMapper, enableSchematization, enableInfinityHandling),
+          objectMapper);
     } else {
       return new RecordService(
-          new SnowflakeTableStreamingRecordMapper(objectMapper, enableSchematization),
+          new SnowflakeTableStreamingRecordMapper(
+              objectMapper, enableSchematization, enableInfinityHandling),
           objectMapper);
     }
   }

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeTableStreamingRecordMapper.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeTableStreamingRecordMapper.java
@@ -20,6 +20,11 @@ class SnowflakeTableStreamingRecordMapper extends StreamingRecordMapper {
     super(mapper, schematizationEnabled);
   }
 
+  public SnowflakeTableStreamingRecordMapper(
+      ObjectMapper mapper, boolean schematizationEnabled, boolean enableInfinitySupport) {
+    super(mapper, schematizationEnabled, enableInfinitySupport);
+  }
+
   @Override
   public Map<String, Object> processSnowflakeRecord(
       RecordService.SnowflakeTableRow row, boolean includeAllMetadata)

--- a/src/main/java/com/snowflake/kafka/connector/records/StreamingRecordMapper.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/StreamingRecordMapper.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.fasterxml.jackson.databind.node.FloatNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.records.RecordService.SnowflakeTableRow;
 import java.util.Map;
 
@@ -13,10 +14,20 @@ abstract class StreamingRecordMapper {
 
   protected final ObjectMapper mapper;
   protected final boolean schematizationEnabled;
+  protected final boolean enableInfinitySupport;
 
   public StreamingRecordMapper(ObjectMapper mapper, boolean schematizationEnabled) {
+    this(
+        mapper,
+        schematizationEnabled,
+        SnowflakeSinkConnectorConfig.ENABLE_STREAMING_INFINITY_HANDLING_DEFAULT);
+  }
+
+  public StreamingRecordMapper(
+      ObjectMapper mapper, boolean schematizationEnabled, boolean enableInfinitySupport) {
     this.mapper = mapper;
     this.schematizationEnabled = schematizationEnabled;
+    this.enableInfinitySupport = enableInfinitySupport;
   }
 
   abstract Map<String, Object> processSnowflakeRecord(
@@ -29,11 +40,31 @@ abstract class StreamingRecordMapper {
     } else if (valueNode.isNull()) {
       value = null;
     } else {
-      value = writeValueAsStringOrNanOrInfinity(valueNode);
+      if (enableInfinitySupport) {
+        value = writeValueAsStringOrNanOrInfinity(valueNode);
+      } else {
+        value = writeValueAsStringOrNan(valueNode);
+      }
     }
     return value;
   }
 
+  /**
+   * Original function that treats both NaN and infinity values as NaN. Used when infinity support
+   * is disabled for backward compatibility.
+   */
+  protected String writeValueAsStringOrNan(JsonNode columnNode) throws JsonProcessingException {
+    if (columnNode instanceof NumericNode && ((NumericNode) columnNode).isNaN()) {
+      return "NaN";
+    } else {
+      return mapper.writeValueAsString(columnNode);
+    }
+  }
+
+  /**
+   * Function that correctly handles both NaN and infinity values. Used when infinity support is
+   * enabled.
+   */
   protected String writeValueAsStringOrNanOrInfinity(JsonNode columnNode)
       throws JsonProcessingException {
     if (columnNode instanceof NumericNode && ((NumericNode) columnNode).isNaN()) {

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/OpenChannelRetryPolicyTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/OpenChannelRetryPolicyTest.java
@@ -3,6 +3,7 @@ package com.snowflake.kafka.connector.internal.streaming;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import dev.failsafe.function.CheckedSupplier;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -107,5 +108,34 @@ public class OpenChannelRetryPolicyTest {
     // Then
     assertSame(mockChannel, result);
     assertEquals(3, attemptCount.get()); // Verify it retried 2 times before succeeding
+  }
+
+  @Test
+  void shouldThrowSFExceptionAfterAllRetriesExhaustedWithNoMoreAttempts() {
+    // Given - MAX_ATTEMPTS is 10 in OpenChannelRetryPolicy
+    SFException exception429 = new SFException(ErrorCode.INTERNAL_ERROR, EXCEPTION_429_MSG);
+    AtomicInteger attemptCount = new AtomicInteger(0);
+
+    CheckedSupplier<SnowflakeStreamingIngestChannel> supplier =
+        () -> {
+          int currentAttempt = attemptCount.incrementAndGet();
+          // If we ever reach 11, fail the test - there should be no 11th attempt
+          if (currentAttempt > 10) {
+            throw new AssertionError(
+                "Should not attempt more than 10 times, but got attempt #" + currentAttempt);
+          }
+          throw exception429; // Always fail with 429
+        };
+
+    // When/Then - should throw SFException after all retries exhausted
+    SFException thrownException =
+        assertThrows(
+            SFException.class,
+            () -> OpenChannelRetryPolicy.executeWithRetry(supplier, channelName));
+
+    // Verify the original SFException is thrown with 429 error
+    assertTrue(thrownException.getMessage().contains("HTTP Status: 429"));
+    // Verify exactly 10 attempts - no more (no 11th attempt), no less
+    assertEquals(10, attemptCount.get(), "Expected exactly 10 attempts");
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2AvroSchematizationIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2AvroSchematizationIT.java
@@ -188,6 +188,7 @@ public class SnowflakeSinkServiceV2AvroSchematizationIT {
   private Map<String, String> prepareConfig() {
     Map<String, String> config = TestUtils.getConfForStreaming();
     config.put(SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG, "true");
+    config.put(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_INFINITY_HANDLING_CONFIG, "true");
     config.put(
         SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD,
         "io.confluent.connect.avro.AvroConverter");

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -1124,6 +1124,52 @@ public class TopicPartitionChannelTest {
     }
   }
 
+  /**
+   * Test that when openChannel always throws SFException with HTTP 429, the channel creation fails
+   * after OpenChannelRetryPolicy exhausts all 10 retries. This verifies the integration between
+   * DirectTopicPartitionChannel.openChannelForTable() and OpenChannelRetryPolicy.executeWithRetry().
+   */
+  @Test
+  public void testOpenChannelFailsAfterRetryPolicyExhaustsAllRetries() {
+    // Only run for one parameterized case to avoid long test times due to retry delays
+    if (this.enableSchematization || this.channelNameFormatVersion != ChannelNameFormatVersion.V1) {
+      return;
+    }
+
+    // Given - openChannel always throws SFException with HTTP 429
+    SFException sfException429 =
+        new SFException(
+            ErrorCode.INTERNAL_ERROR,
+            "Encountered an error while calling a Snowflake API. HTTP Status: 429");
+
+    Mockito.when(mockStreamingClient.openChannel(any(OpenChannelRequest.class)))
+        .thenThrow(sfException429);
+
+    // When/Then - creating TopicPartitionChannel should fail with SFException after all retries
+    SFException thrownException =
+        assertThrows(
+            SFException.class,
+            () ->
+                createTopicPartitionChannel(
+                    mockStreamingClient,
+                    topicPartition,
+                    testChannelName,
+                    TEST_TABLE_NAME,
+                    sfConnectorConfig,
+                    mockKafkaRecordErrorReporter,
+                    mockSinkTaskContext,
+                    mockSnowflakeConnectionService,
+                    mockTelemetryService,
+                    this.schemaEvolutionService));
+
+    // Verify the exception contains the HTTP 429 error
+    Assert.assertTrue(thrownException.getMessage().contains("HTTP Status: 429"));
+
+    // Verify openChannel was called exactly 10 times (MAX_ATTEMPTS in OpenChannelRetryPolicy)
+    Mockito.verify(mockStreamingClient, Mockito.times(10))
+        .openChannel(any(OpenChannelRequest.class));
+  }
+
   @Test
   public void assignANewChannel_whenNoOffsetIsPresentInSnowflake() {
     // given


### PR DESCRIPTION
1. Do not retry indefinitely on open channel errors as operator will restart it on the failure, limited the number of attempts to 10.
2. Updated snowflake-ingest-java version that includes restoring the INSERT_THROTTLE_MAX_RETRY_COUNT to 60
3. Added a new config `snowflake.streaming.enable.handling.infinity.values` to handle the behavioural change around handling infinity values in SNOWPIPE STREAMING mode. 