### PR TITLE
Marked `org.apache.avro:avro` as provided (#166)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,7 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>1.11.4</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Cherry pick 3.1.x latest commit