### PR TITLE
INC-11685: demote idle Snowpipe flush logging from INFO to DEBUG in SnowflakeSinkServiceV1

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -1022,7 +1022,7 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
 
       // Just checking buffer size, no atomic operation required
       if (buffer.isEmpty()) {
-        LOGGER.info(
+        LOGGER.debug(
             "Buffer for pipe: {}, tableName: {}, stageName: {}, nothing to be flushed",
             pipeName,
             tableName,
@@ -1119,7 +1119,7 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
 
     private void flush(final SnowpipeBuffer buff) {
       if (buff == null || buff.isEmpty()) {
-        LOGGER.info("Buffer empty, nothing to be flushed");
+        LOGGER.debug("Buffer empty, nothing to be flushed");
         return;
       }
       this.previousFlushTimeStamp = System.currentTimeMillis();


### PR DESCRIPTION
## Summary
Demotes the two idle "nothing to be flushed" log statements in `SnowflakeSinkServiceV1` from INFO to DEBUG. This is a logging-only change with no behavioral impact.

