### PR TITLE
demo: do not review | CC-41637: fix Snowflake sink ghost lag and restart re-read with a connector-only decided frontier in preCommit

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -260,6 +260,22 @@ public class SnowflakeSinkConnectorConfig {
           + " enabled, disabling this config could have ramifications. Please consult Snowflake"
           + " support before setting this to false.";
 
+  // Advance the committed Kafka offset past intentionally skipped null/tombstone records so
+  // consumer-group lag does not grow on tombstone-heavy topics with behavior.on.null.values=IGNORE.
+  // Advisory only: recovery always re-seeks to the durable Snowflake token, so a committed offset
+  // ahead of the token never causes a real record to be skipped. Default off.
+  public static final String ENABLE_NULL_RECORD_OFFSET_ADVANCE =
+      "enable.null.record.offset.advance";
+  public static final boolean ENABLE_NULL_RECORD_OFFSET_ADVANCE_DEFAULT = false;
+
+  // Persist a recovery floor in the OffsetAndMetadata.metadata of the consumer-offset commit so
+  // open() can re-seek past a skipped tombstone run on restart instead of re-reading it. The
+  // committed offset itself is unchanged. A stale or missing floor falls back to a harmless
+  // re-read, never data loss. Only effective when ENABLE_NULL_RECORD_OFFSET_ADVANCE is also on.
+  // Default off.
+  public static final String ENABLE_METADATA_FLOOR_RECOVERY = "enable.metadata.floor.recovery";
+  public static final boolean ENABLE_METADATA_FLOOR_RECOVERY_DEFAULT = false;
+
   // related to ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG /
   // enable.streaming.channel.offset.migration above
   public static final String SNOWPIPE_STREAMING_CHANNEL_NAME_INCLUDE_CONNECTOR_NAME_CONFIG =

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -389,11 +389,35 @@ public class SnowflakeSinkTask extends SinkTask {
     try {
       offsets.forEach(
           (topicPartition, offsetAndMetadata) -> {
-            long offset = sink.getOffset(topicPartition);
-            if ((ingestionMethodConfig == IngestionMethodConfig.SNOWPIPE && offset != 0)
-                || (ingestionMethodConfig == IngestionMethodConfig.SNOWPIPE_STREAMING
-                    && offset != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE)) {
-              committedOffsets.put(topicPartition, new OffsetAndMetadata(offset));
+            // Compute the decided frontier from the framework's consumed position (this key's
+            // offset). That position includes records dropped by SMTs, which the sink never sees,
+            // so it is what lets preCommit clear lag caused by those drops as well as skipped
+            // nulls. Everything below the frontier is decided, so committing it clears the lag
+            // without stepping over a real record still in flight.
+            long frontier = sink.getDecidedFrontier(topicPartition, offsetAndMetadata.offset());
+            if (frontier != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
+              // Commit the frontier and carry a recovery floor of frontier - 1 so open() re-seeks
+              // to exactly the frontier. A frontier of 0 gives a negative floor (only before
+              // anything is consumed), so attach a bare offset in that case.
+              long floor = frontier - 1L;
+              committedOffsets.put(
+                  topicPartition,
+                  floor < 0L
+                      ? new OffsetAndMetadata(frontier)
+                      : new OffsetAndMetadata(frontier, "floor=" + floor));
+            } else {
+              // Feature off, Snowpipe V1, or no channel yet: preserve the original behaviour.
+              long offset = sink.getOffset(topicPartition);
+              if ((ingestionMethodConfig == IngestionMethodConfig.SNOWPIPE && offset != 0)
+                  || (ingestionMethodConfig == IngestionMethodConfig.SNOWPIPE_STREAMING
+                      && offset != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE)) {
+                String floorMetadata = sink.getOffsetMetadata(topicPartition);
+                committedOffsets.put(
+                    topicPartition,
+                    floorMetadata == null
+                        ? new OffsetAndMetadata(offset)
+                        : new OffsetAndMetadata(offset, floorMetadata));
+              }
             }
           });
     } catch (Exception e) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -54,6 +54,31 @@ public interface SnowflakeSinkService {
   long getOffset(TopicPartition topicPartition);
 
   /**
+   * The metadata string to attach to the consumer-offset commit for this partition (e.g. {@code
+   * "floor=204"}), carrying the recovery floor that {@code open()} reads back to re-seek past a
+   * skipped tombstone run. Returns {@code null} when no metadata should be attached.
+   *
+   * @param topicPartition topic and partition
+   * @return commit metadata string, or {@code null}
+   */
+  default String getOffsetMetadata(TopicPartition topicPartition) {
+    return null;
+  }
+
+  /**
+   * Given the framework's consumed position for this partition, return the highest offset it is
+   * safe to treat as fully handled. The caller supplies the consumed position because it includes
+   * offsets dropped by SMTs, which the sink never sees. Returns {@code -1} when the feature is off.
+   *
+   * @param topicPartition topic and partition
+   * @param consumedHwm the framework's consumed position for this partition
+   * @return the decided frontier, or {@code -1}
+   */
+  default long getDecidedFrontier(TopicPartition topicPartition, long consumedHwm) {
+    return -1L;
+  }
+
+  /**
    * get the number of partitions assigned to this sink service
    *
    * @return number of partitions

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -2,6 +2,8 @@ package com.snowflake.kafka.connector.internal.streaming;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DEFAULT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_METADATA_FLOOR_RECOVERY;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_METADATA_FLOOR_RECOVERY_DEFAULT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.DURATION_BETWEEN_GET_OFFSET_TOKEN_RETRY;
@@ -15,6 +17,9 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
@@ -44,13 +49,18 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import net.snowflake.ingest.streaming.*;
 import net.snowflake.ingest.utils.SFException;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -84,6 +94,39 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
   // channel versions compatible.
   private final AtomicLong currentConsumerGroupOffset =
       new AtomicLong(NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE);
+
+  // Intentionally skipped (null/tombstone) Kafka offsets, held as a coalesced set of ranges. The
+  // commit and recovery floor is the top of the contiguous run of skipped offsets above the durable
+  // token (see contiguousSkipFloor), so it never leapfrogs a real record that was consumed but is
+  // not yet durable. closedOpen ranges merge adjacent integers. In-memory, reset on every (re)open.
+  // Every access synchronizes on the set.
+  private final RangeSet<Long> skippedRanges = TreeRangeSet.create();
+
+  // Kafka offsets of real records this channel has buffered but not yet confirmed durable in
+  // Snowflake. The decided frontier is the minimum of this set, or the consumed position when it is
+  // empty; everything below the frontier is decided (durably written, a skipped null, or a record
+  // dropped upstream), so the frontier never steps over a real record that is not yet durable. An
+  // offset enters here when its record is buffered (transformAndSend), is pruned once the durable
+  // token passes it (getDecidedFrontier), and the whole set is cleared on (re)open/reset. A record
+  // that was dead-lettered is not tracked here: the framework awaits its DLQ produce before commit,
+  // and a later row's flush advances the token past it. Guarded by its own monitor.
+  private final java.util.TreeSet<Long> pendingRealOffsets = new java.util.TreeSet<>();
+
+  // Whether the in-memory committed-offset advance is enabled.
+  private final boolean enableNullRecordOffsetAdvance;
+
+  // Whether the recovery floor is persisted into the OffsetAndMetadata.metadata of the
+  // consumer-offset commit and read back at open() to re-seek past the skipped run. Only effective
+  // when enableNullRecordOffsetAdvance is also true.
+  private final boolean enableMetadataFloorRecovery;
+
+  // Prefix for the floor value embedded in OffsetAndMetadata.metadata, e.g. "floor=204".
+  private static final String METADATA_FLOOR_PREFIX = "floor=";
+
+  // Config key carrying the Connect sink consumer group id (e.g. "connect-<connectorName>").
+  // Required to read the committed floor back at open(), because the original Connect connector
+  // name is not recoverable inside the connector (Utils.convertAppName munges the "name" config).
+  private static final String METADATA_FLOOR_GROUP_ID_CONFIG = "metadata.floor.group.id";
 
   // Indicates whether we need to skip and discard any leftover rows in the current batch, this
   // could happen when the channel gets invalidated and reset, then anything left in the buffer
@@ -245,6 +288,19 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
     this.enableSchemaEvolution = this.enableSchematization && hasSchemaEvolutionPermission;
     this.schemaEvolutionService = schemaEvolutionService;
 
+    this.enableNullRecordOffsetAdvance =
+        Boolean.parseBoolean(
+            this.sfConnectorConfig.getOrDefault(
+                SnowflakeSinkConnectorConfig.ENABLE_NULL_RECORD_OFFSET_ADVANCE,
+                Boolean.toString(
+                    SnowflakeSinkConnectorConfig.ENABLE_NULL_RECORD_OFFSET_ADVANCE_DEFAULT)));
+
+    this.enableMetadataFloorRecovery =
+        Boolean.parseBoolean(
+            this.sfConnectorConfig.getOrDefault(
+                ENABLE_METADATA_FLOOR_RECOVERY,
+                Boolean.toString(ENABLE_METADATA_FLOOR_RECOVERY_DEFAULT)));
+
     this.channelOffsetTokenMigrator = new ChannelOffsetTokenMigrator(conn, telemetryService);
 
     if (isEnableChannelOffsetMigration(sfConnectorConfig)) {
@@ -261,6 +317,11 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
     final long lastCommittedOffsetToken = fetchOffsetTokenWithRetry();
     this.offsetPersistedInSnowflake.set(lastCommittedOffsetToken);
     this.processedOffset.set(lastCommittedOffsetToken);
+    // A fresh (re)open re-seeks and re-reads, so nothing is in flight yet. Clear the pending-real
+    // set so a stale entry from a prior incarnation cannot hold the frontier back.
+    synchronized (pendingRealOffsets) {
+      pendingRealOffsets.clear();
+    }
 
     // setup telemetry and metrics
     String connectorName =
@@ -284,12 +345,124 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
     this.insertErrorMapper = insertErrorMapper;
 
     if (lastCommittedOffsetToken != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
-      this.sinkTaskContext.offset(this.topicPartition, lastCommittedOffsetToken + 1L);
+      // Recovery normally re-seeks to durable token + 1. If the metadata-floor feature is on, read
+      // the floor carried in the commit's metadata and re-seek to max(token, floor) + 1 instead,
+      // skipping a contiguous run of already-skipped tombstones. A stale, missing, or unreadable
+      // floor falls back to token + 1, a harmless re-read of tombstones, never data loss.
+      long seekTarget = lastCommittedOffsetToken + 1L;
+      if (enableMetadataFloorRecovery && enableNullRecordOffsetAdvance) {
+        long floorH = readMetadataFloor(lastCommittedOffsetToken);
+        if (floorH > lastCommittedOffsetToken) {
+          seekTarget = floorH + 1L;
+          LOGGER.info(
+              "TopicPartitionChannel:{}, metadata-floor recovery: token={}, floorH={}, seeking"
+                  + " to {} (skipping re-read of skipped run)",
+              this.getChannelName(),
+              lastCommittedOffsetToken,
+              floorH,
+              seekTarget);
+        }
+      }
+      this.sinkTaskContext.offset(this.topicPartition, seekTarget);
+    } else if (enableMetadataFloorRecovery && enableNullRecordOffsetAdvance) {
+      // No durable token yet. Read the recovery floor rather than trusting the raw committed Kafka
+      // offset. A recorded leading run of tombstones from offset 0 has a floor that is never a real
+      // record (the run stops at the first non-skip), so seeking to floor + 1 skips only tombstones.
+      // With no readable floor, fall through to the committed offset, at worst a harmless re-read.
+      long floorH = readMetadataFloor(lastCommittedOffsetToken);
+      if (floorH > NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
+        long seekTarget = floorH + 1L;
+        LOGGER.info(
+            "TopicPartitionChannel:{}, token-null metadata-floor recovery: floorH={}, seeking to {}"
+                + " (skipping re-read of leading skipped run)",
+            this.getChannelName(),
+            floorH,
+            seekTarget);
+        this.sinkTaskContext.offset(this.topicPartition, seekTarget);
+      } else {
+        LOGGER.info(
+            "TopicPartitionChannel:{}, offset token is NULL and no recovery floor, relying on Kafka"
+                + " committed offset (clamped to the decided frontier by the commit fix)",
+            this.getChannelName());
+      }
     } else {
       LOGGER.info(
           "TopicPartitionChannel:{}, offset token is NULL, will rely on Kafka to send us the"
               + " correct offset instead",
           this.getChannelName());
+    }
+  }
+
+  /**
+   * Read the recovery floor previously persisted in the committed OffsetAndMetadata.metadata for
+   * this connector's consumer group and topic-partition, via AdminClient.listConsumerGroupOffsets.
+   * Best-effort: returns {@link #NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE} on any error, missing
+   * metadata, or unparsable value, so recovery falls back to token + 1. The AdminClient bootstrap
+   * config is sourced from the connector's {@code admin.override.*} properties.
+   *
+   * @param durableToken the durable Snowflake token (used only for logging context)
+   * @return the parsed floor, or {@code NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE} if none
+   */
+  private long readMetadataFloor(long durableToken) {
+    // The Connect sink consumer group is "connect-<connector name>" using the original Connect REST
+    // name, which is not available inside the connector because Utils.convertAppName() munges the
+    // "name" config. So the group id must be supplied explicitly via the "metadata.floor.group.id"
+    // config. If it is absent, skip the read (harmless fallback to token + 1).
+    String groupId = this.sfConnectorConfig.get(METADATA_FLOOR_GROUP_ID_CONFIG);
+    if (Strings.isNullOrEmpty(groupId)) {
+      LOGGER.info(
+          "TopicPartitionChannel:{}, metadata-floor read skipped: no '{}' config (cannot derive"
+              + " the Connect consumer group from the munged connector name)",
+          this.getChannelName(),
+          METADATA_FLOOR_GROUP_ID_CONFIG);
+      return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+    }
+
+    Properties adminProps = new Properties();
+    for (Map.Entry<String, String> entry : this.sfConnectorConfig.entrySet()) {
+      String key = entry.getKey();
+      if (key.startsWith("admin.override.")) {
+        adminProps.put(key.substring("admin.override.".length()), entry.getValue());
+      }
+    }
+
+    try (AdminClient adminClient = AdminClient.create(adminProps)) {
+      Map<TopicPartition, OffsetAndMetadata> committed =
+          adminClient
+              .listConsumerGroupOffsets(
+                  groupId,
+                  new ListConsumerGroupOffsetsOptions()
+                      .topicPartitions(Collections.singletonList(this.topicPartition)))
+              .partitionsToOffsetAndMetadata()
+              .get(5, TimeUnit.SECONDS);
+      OffsetAndMetadata oam = committed == null ? null : committed.get(this.topicPartition);
+      if (oam == null
+          || oam.metadata() == null
+          || !oam.metadata().startsWith(METADATA_FLOOR_PREFIX)) {
+        LOGGER.info(
+            "TopicPartitionChannel:{}, metadata-floor read: no floor in committed metadata"
+                + " (group={}, token={}, committedOffset={}, metadata={})",
+            this.getChannelName(),
+            groupId,
+            durableToken,
+            oam == null ? "<none>" : oam.offset(),
+            oam == null ? "<none>" : oam.metadata());
+        return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+      }
+      long parsed = Long.parseLong(oam.metadata().substring(METADATA_FLOOR_PREFIX.length()));
+      LOGGER.info(
+          "TopicPartitionChannel:{}, metadata-floor read: floorH={} (group={}, token={})",
+          this.getChannelName(),
+          parsed,
+          groupId,
+          durableToken);
+      return parsed;
+    } catch (Exception e) {
+      LOGGER.info(
+          "TopicPartitionChannel:{}, metadata-floor read failed, falling back to token+1: {}",
+          this.getChannelName(),
+          e.getMessage());
+      return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
     }
   }
 
@@ -434,6 +607,14 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
               response.hasErrors());
 
           handleInsertRowFailure(response.getInsertErrors(), kafkaSinkRecord);
+        } else if (enableNullRecordOffsetAdvance) {
+          // A real record was successfully buffered and will become durable on the next flush.
+          // Record it as pending so the decided frontier cannot advance the committed offset or the
+          // recovery floor past it until the durable token confirms it. A record on the hasErrors()
+          // branch above is dead-lettered and deliberately not tracked here.
+          synchronized (pendingRealOffsets) {
+            pendingRealOffsets.add(kafkaSinkRecord.kafkaOffset());
+          }
         }
       }
 
@@ -593,14 +774,121 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
   @Override
   public long getOffsetSafeToCommitToKafka() {
     final long committedOffsetInSnowflake = fetchOffsetTokenWithRetry();
-    if (committedOffsetInSnowflake == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
-      return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
-    } else {
-      // Return an offset which is + 1 of what was present in snowflake.
-      // Idea of sending + 1 back to Kafka is that it should start sending offsets after task
-      // restart from this offset
-      return committedOffsetInSnowflake + 1;
+    final long tokenBasedOffset =
+        committedOffsetInSnowflake == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE
+            ? NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE
+            // Return an offset which is + 1 of what was present in snowflake.
+            // Idea of sending + 1 back to Kafka is that it should start sending offsets after task
+            // restart from this offset
+            : committedOffsetInSnowflake + 1;
+
+    if (!enableNullRecordOffsetAdvance) {
+      return tokenBasedOffset;
     }
+
+    // Also advance past a contiguous run of intentionally skipped null records. The committed offset
+    // becomes max(token + 1, contiguousSkipFloor + 1). The contiguous floor stops at the first
+    // non-skipped offset, so it never steps over a real record that is buffered but not yet durable.
+    final long floor = contiguousSkipFloor(committedOffsetInSnowflake);
+    final long skipBasedOffset =
+        (floor > committedOffsetInSnowflake)
+            ? floor + 1
+            : NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+    return Math.max(tokenBasedOffset, skipBasedOffset);
+  }
+
+  /**
+   * Given the framework's consumed position for this partition, return the highest offset it is safe
+   * to treat as fully handled, so the committed offset and the recovery floor can move up to it. The
+   * frontier is the lowest real record buffered but not yet durable, or the consumed position when
+   * nothing is pending. Everything below the frontier is decided, so it can never step over a real
+   * record still in flight, because such a record would itself be the minimum of the pending set.
+   * The pending set is pruned against the live durable token first, so a real record that has since
+   * become durable no longer holds the frontier back.
+   *
+   * <p>The consumed position must be supplied by the caller because it includes offsets dropped by
+   * SMTs, which the sink never sees, so the connector's own state cannot bound the frontier across
+   * such a gap.
+   *
+   * @param consumedHwm the framework's consumed position for this partition
+   * @return the decided frontier, or {@link #NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE} when the
+   *     feature is off
+   */
+  @Override
+  public long getDecidedFrontier(long consumedHwm) {
+    if (!enableNullRecordOffsetAdvance) {
+      return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+    }
+    final long durableToken = fetchOffsetTokenWithRetry();
+    synchronized (pendingRealOffsets) {
+      // Prune reals that have since become durable: the token passing an offset means that real, or
+      // a later one sharing its flush, registered, so it no longer bounds the frontier.
+      if (durableToken != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
+        pendingRealOffsets.headSet(durableToken + 1L).clear();
+      }
+      if (pendingRealOffsets.isEmpty()) {
+        // Nothing real is in flight, so the entire consumed run is durable or decided-dropped.
+        return consumedHwm;
+      }
+      // The lowest real still in flight is the first genuinely-unfinished offset; stop there.
+      return pendingRealOffsets.first();
+    }
+  }
+
+  @Override
+  public void markSkippedRecordOffset(long offset) {
+    if (enableNullRecordOffsetAdvance) {
+      // Record this skipped offset as a coalescing range. closedOpen(offset, offset+1) makes
+      // adjacent integers merge, so a run of consecutive tombstones becomes one interval.
+      synchronized (skippedRanges) {
+        skippedRanges.add(Range.closedOpen(offset, offset + 1L));
+      }
+    }
+  }
+
+  /**
+   * Returns the highest Kafka offset {@code H} such that every offset in {@code (durableToken, H]}
+   * was an intentionally skipped tombstone, that is, the top of the unbroken skipped run starting
+   * immediately above the durable token. Returns {@code durableToken} when the offset right above
+   * the token was not skipped. Because the run stops at the first offset that is not a recorded
+   * skip, a real record, a dead-lettered record, or an unconsumed gap is always a stop boundary and
+   * can never be leapfrogged.
+   */
+  private long contiguousSkipFloor(long durableToken) {
+    synchronized (skippedRanges) {
+      Range<Long> run = skippedRanges.rangeContaining(durableToken + 1L);
+      if (run == null) {
+        return durableToken;
+      }
+      // run is closedOpen [a, b) and contains durableToken+1, so [durableToken+1, b) are all
+      // skipped; the highest skipped offset in that contiguous run is b-1.
+      return run.upperEndpoint() - 1L;
+    }
+  }
+
+  @Override
+  public String getMetadataFloorForCommit() {
+    if (!enableMetadataFloorRecovery || !enableNullRecordOffsetAdvance) {
+      return null;
+    }
+    // The floor is the top of the contiguous run of skipped offsets starting at durableToken + 1,
+    // so it can never point past a record that still needs to be written. This is computed even with
+    // no durable token yet: the anchor is offset 0 in that case, so a leading run of tombstones
+    // yields a real floor that lets open() seek past it. When the offset above the anchor was not
+    // skipped, there is nothing to advance past, so emit no metadata.
+    final long durableToken = offsetPersistedInSnowflake.get();
+    final long floorValue = contiguousSkipFloor(durableToken);
+    if (floorValue <= durableToken) {
+      return null;
+    }
+    String floor = METADATA_FLOOR_PREFIX + floorValue;
+    LOGGER.info(
+        "TopicPartitionChannel:{}, metadata-floor emit: token={}, floorH={}, metadata={}",
+        this.getChannelName(),
+        durableToken,
+        floorValue,
+        floor);
+    return floor;
   }
 
   @Override
@@ -726,6 +1014,12 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
     // might get rejected.
     this.offsetPersistedInSnowflake.set(offsetRecoveredFromSnowflake);
     this.processedOffset.set(offsetRecoveredFromSnowflake);
+    // The buffer was discarded and the channel re-seeks, so nothing is in flight anymore. Clear the
+    // pending-real set; the reals will re-enter it as the re-read records flow back through
+    // transformAndSend.
+    synchronized (pendingRealOffsets) {
+      pendingRealOffsets.clear();
+    }
 
     // Set the flag so that any leftover rows in the buffer should be skipped, it will be
     // re-ingested since the offset in kafka was reset

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -102,6 +102,10 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
 
   private final boolean enableChannelNameV2Usage;
 
+  // When true, record skipped null-record offsets on the channel so the committed Kafka offset can
+  // advance past them.
+  private final boolean enableNullRecordOffsetAdvance;
+
   /**
    * Key is formulated in {@link #partitionChannelKey(String, String, int)}
    *
@@ -176,6 +180,13 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
             .orElse(
                 SnowflakeSinkConnectorConfig
                     .SNOWPIPE_STREAMING_CHANNEL_NAME_INCLUDE_CONNECTOR_NAME_DEFAULT);
+
+    this.enableNullRecordOffsetAdvance =
+        Boolean.parseBoolean(
+            connectorConfig.getOrDefault(
+                SnowflakeSinkConnectorConfig.ENABLE_NULL_RECORD_OFFSET_ADVANCE,
+                Boolean.toString(
+                    SnowflakeSinkConnectorConfig.ENABLE_NULL_RECORD_OFFSET_ADVANCE_DEFAULT)));
 
     this.streamingIngestClient =
         StreamingClientProvider.getStreamingClientProviderInstance()
@@ -310,6 +321,15 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     for (SinkRecord record : records) {
       // check if it needs to handle null value records
       if (recordService.shouldSkipNullValue(record, behaviorOnNullValues)) {
+        // Remember the skipped offset on its channel so the committed Kafka offset can advance past
+        // it (otherwise consumer lag grows on tombstone-heavy topics).
+        if (enableNullRecordOffsetAdvance) {
+          String partitionChannelKey = partitionChannelKey(record.topic(), record.kafkaPartition());
+          TopicPartitionChannel channel = partitionsToChannel.get(partitionChannelKey);
+          if (channel != null) {
+            channel.markSkippedRecordOffset(record.kafkaOffset());
+          }
+        }
         continue;
       }
 
@@ -361,6 +381,22 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
           topicPartition.partition());
       return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
     }
+  }
+
+  @Override
+  public String getOffsetMetadata(TopicPartition topicPartition) {
+    String partitionChannelKey =
+        partitionChannelKey(topicPartition.topic(), topicPartition.partition());
+    TopicPartitionChannel channel = partitionsToChannel.get(partitionChannelKey);
+    return channel == null ? null : channel.getMetadataFloorForCommit();
+  }
+
+  @Override
+  public long getDecidedFrontier(TopicPartition topicPartition, long consumedHwm) {
+    String partitionChannelKey =
+        partitionChannelKey(topicPartition.topic(), topicPartition.partition());
+    TopicPartitionChannel channel = partitionsToChannel.get(partitionChannelKey);
+    return channel == null ? -1L : channel.getDecidedFrontier(consumedHwm);
   }
 
   @Override

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/TopicPartitionChannel.java
@@ -81,4 +81,40 @@ public interface TopicPartitionChannel extends ExposingInternalsTopicPartitionCh
   String getChannelName();
 
   void setLatestConsumerGroupOffset(long consumerOffset);
+
+  /**
+   * Record that a null/tombstone record at {@code offset} was intentionally skipped (e.g.
+   * behavior.on.null.values=IGNORE), so {@link #getOffsetSafeToCommitToKafka()} can advance the
+   * committed Kafka offset past skipped records without writing them and avoid false consumer-group
+   * lag. No-op unless the advance feature is enabled.
+   *
+   * @param offset Kafka offset of the skipped null record
+   */
+  default void markSkippedRecordOffset(long offset) {}
+
+  /**
+   * The metadata string to attach to the next consumer-offset commit for this partition, carrying
+   * the recovery floor (e.g. {@code "floor=204"}) so {@code open()} can re-seek past a skipped run
+   * on restart. The committed offset itself is unchanged. Returns {@code null} when the feature is
+   * off or there is no skipped run to advance past.
+   *
+   * @return the floor metadata string, or {@code null} for no metadata
+   */
+  default String getMetadataFloorForCommit() {
+    return null;
+  }
+
+  /**
+   * Given the framework's consumed position for this partition, return the highest offset it is safe
+   * to treat as fully handled, that is the lowest real record buffered but not yet durable, or the
+   * consumed position when nothing is in flight. Both the committed offset and the recovery floor
+   * derive from this one number. Returns {@code NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE} when the
+   * feature is off.
+   *
+   * @param consumedHwm the framework's consumed position for this partition
+   * @return the decided frontier, or {@code NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE}
+   */
+  default long getDecidedFrontier(long consumedHwm) {
+    return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+  }
 }


### PR DESCRIPTION
> Demonstration PR. Please do not review or merge. It exists to illustrate the decided-frontier approach for CC-41637.

> Base note: this targets the 3.4.x release branch, which does not carry the earlier Approach-1 base (the enable.null.record.offset.advance skip advance) that the frontier builds on. So this PR includes that prerequisite plus the frontier on top of it. Both feature flags default to false, so the connector is unchanged unless enabled.

# The bug (CC-41637)

The Snowflake sink advances the committed Kafka offset only for records it has durably written to Snowflake, which produces two connected problems.
P1, ghost lag: whenever a run of records is consumed but nothing is durably written, the committed offset freezes and consumer-group monitoring reports lag that never drains, even though the connector is healthy.
This happens for a run of null tombstones dropped inside `put()` under `behavior.on.null.values=IGNORE`, and it also happens for records removed by a Filter SMT or a failed converter before they ever reach the sink, which the connector cannot even name.
P2, restart re-read and potential data loss: Snowflake is a re-seek sink.
On restart the connector ignores the committed Kafka offset and rewinds to its own durable channel offset token plus one, so a run of dropped records above the token is re-consumed and re-dropped on every restart, and any earlier fix that merely pushed the committed Kafka offset forward could seek past a real record that was buffered but not yet durable and lose it.

# The fix: commit the decided frontier, computed entirely in preCommit

The correct rule is not "only commit what was durably written."
It is "never commit past a record that the connector intends to write and has not yet made durable."
Every offset at or below the committed offset must be decided, and decided means one of two things: the record was durably written, or the connector deliberately decided it will never be written (a dropped null, an SMT or converter drop, a dead-lettered record).
Committing a decided offset is always safe; committing past a record still in flight is the only way to lose data.

Because the set of reasons an offset is decided is open-ended and includes offsets the connector never sees (a Filter SMT removes a record before `put()`), the connector tracks the complement instead: the set P of Kafka offsets of real records that have been buffered into the Snowflake channel but are not yet durable.
The connector always knows P completely, with no invisible members, because it can only buffer a record it actually received.
The decided frontier is then

```
frontier = P.isEmpty() ? consumedHighWaterMark : min(P)
```

Everything strictly below the frontier is decided, so committing the frontier clears both null-drop and SMT-drop ghost lag, and the frontier can never sit above a real record still in flight because such a record would itself be the minimum of P.
The connector commits `min(P)` itself, not `min(P) - 1`, because a committed offset in Connect is the next offset to consume, so committing `min(P)` makes the lowest pending real record be re-read after a restart, which is exactly what we want.
As buffered records flush and leave P, the frontier ratchets forward on its own and heals to zero once the last pending real record is durable, sweeping up trailing tombstones and SMT drops that the stock connector would carry as permanent ghost lag.

This is computed and returned entirely in `preCommit`.
`preCommit` already receives the framework's consumed position for each partition as its argument, and that position includes SMT-filtered and converter-dropped offsets, because those advance the consumed position upstream of the sink.
So `preCommit` has every input the frontier needs: the consumed high-water mark from its argument, and P plus the live durable token from the connector itself.
Whatever `preCommit` returns is what the runtime commits, so returning the frontier from `preCommit` is the whole mechanism.

# Connector-only, no framework change

There is no new framework hook and no ce-kafka change.
The fix runs on a stock Kafka Connect runtime, any unmodified Apache Kafka or ce-kafka build, and ships through the connector release pipeline alone with no framework patch and no KIP dependency.
A commit-time framework hook and `preCommit` are structurally equivalent: both return the value that becomes the committed offset, both receive the consumed position, and both run in the same commit cycle, so there is no offset a hook could commit that `preCommit` cannot return directly.
Two already-shipped connectors fix ghost lag from inside `preCommit`, Elasticsearch with a per-record offset tracker and BigQuery with a seen-versus-offered comparison, which is direct evidence that the connector layer is sufficient.

# Why it is data-loss-safe

The safety of the change rests on a single invariant: every real record that has been consumed is, at every commit, either already durable in Snowflake or currently in P, and never in neither state.
This holds for free from the order of operations in Connect.
The framework hands a batch to `put()`; `put()` buffers each real record, which is the point at which its offset enters P, before `put()` returns; and only after `put()` returns does the framework advance the consumed high-water mark that `preCommit` later reads.
So by the time any commit observes the consumed high-water mark, every consumed real record below it is already in P or already durable.
There is no window in which a consumed real record is missing from both, and that window is exactly what a data-loss bug would require.
The one implementation obligation is that a real offset is added to P in the same place the record is buffered, so no code path can buffer a real record without recording it.
This PR meets that obligation by adding the offset to the pending-real set on the success branch of the buffering call in `DirectTopicPartitionChannel`, co-located with the buffering.

The change touches only the advisory committed offset and the recovery seek target.
It never changes row content and it adds no new writer to Snowflake, so it does not introduce any racing stale overwrite of a key.
A dead-lettered record is deliberately not tracked in P, because the framework awaits its dead-letter produce before it commits and a later real row's flush moves the durable token past its offset, so it is correctly treated as a decided drop.
The set is pruned against the live durable token on every frontier computation, so a real record that has since become durable no longer holds the frontier back, and it is cleared on every open and on channel reset so a stale entry from a prior incarnation can never hold the frontier back either.

# Snowflake is a re-seek sink, so the recovery floor is included (P2)

Because Snowflake recovers from its own durable token and not from the committed Kafka offset, committing the frontier alone would not change restart behaviour.
So the connector also persists a recovery floor equal to `frontier - 1` in the commit metadata string as `floor=<H>`, reusing the `OffsetAndMetadata.metadata` field already carried in every consumer-offset commit.
No new topic, no marker row, no extra SQL.
On `open()` the connector reads that floor back through `AdminClient.listConsumerGroupOffsets` and re-seeks to `max(durableToken, floor) + 1`, which is exactly the frontier, so the lowest pending real record is re-read and nothing that was not already decided is skipped.
The durable token remains the exactly-once anchor and is never written by this change.
A missing, stale, or unreadable floor falls back to seeking `durableToken + 1`, which is a harmless re-read of decided records and never a skip.

The floor also covers the case where Snowflake has no durable token yet.
The earlier connector code fell straight through to trusting the raw committed Kafka offset there, which under an offset-advance fix could sit past a buffered-not-durable real record.
This PR instead reads the floor at the token-null boundary too: if a leading run of tombstones from offset 0 was recorded, its top is a decided-drop boundary and seeking past it skips only tombstones, and if there is no floor it falls back to the committed offset, which the commit fix has already clamped to the decided frontier, so it is at worst a harmless re-read.

# Config flags and default-off safety

The change is gated behind configuration and is off by default, so an unconfigured connector is byte-for-byte unaffected and takes the original `preCommit` path.

- `enable.null.record.offset.advance` (default `false`) turns the decided-frontier commit on. When it is off, `getDecidedFrontier` returns the sentinel and `preCommit` runs the original durable-offset path unchanged.
- `enable.metadata.floor.recovery` (default `false`) turns the P2 recovery floor on. It only takes effect when `enable.null.record.offset.advance` is also on. When off, `open()` re-seeks to the original `durableToken + 1`.
- `metadata.floor.group.id` supplies the Connect sink consumer group id used to read the floor back at `open()`. The original Connect REST connector name is not recoverable inside the connector because `Utils.convertAppName` munges the `name` config, so the group id must be provided by the deployment. If it is absent, the floor read is skipped and recovery falls back to `durableToken + 1`, a harmless re-read.

When the feature is off, or the ingestion method is Snowpipe V1, or the streaming channel is not yet open, `getDecidedFrontier` returns the sentinel and `preCommit` preserves the original behaviour exactly.

# Test plan

Both tests run on a stock Connect runtime to prove no framework patch is involved.

1. Interleaved null and SMT ghost-lag drain (P1).
   Configure a Filter SMT and `behavior.on.null.values=IGNORE`, and produce an interleaved stream of real records, null tombstones, and SMT-dropped records into a single partition, mirroring the worked example where offsets 100 through 119 mix durable writes, dropped nulls, invisible SMT drops, and reals buffered but not yet flushed.
   Hold a small flush lag so several reals sit in P at once.
   Assert that the committed offset for the partition sits at `min(P)` while reals are pending and advances step by step as each buffered real flushes and leaves P, and that once the last pending real is durable the committed offset reaches the consumed high-water mark and lag drains to zero, including over the trailing tombstones and the SMT-dropped run.
   The stock connector freezes at `durableToken + 1` and carries permanent ghost lag over the trailing drops, so the two are directly distinguishable.

2. Token-null restart with a buffered-not-durable real (P2).
   Drive an interleaved run where a real record is buffered but not yet durable among SMT drops and tombstones, with `enable.null.record.offset.advance`, `enable.metadata.floor.recovery`, and `metadata.floor.group.id` all set.
   Hard-kill the task inside the durability window, in both the durable-token-present and the token-null states, and restart it.
   Assert that on `open()` the connector re-seeks to the frontier, `max(durableToken, floor) + 1` when a token is present or `floor + 1` at the token-null boundary, so the buffered-not-durable real record is re-read and lands in Snowflake, and that no decided record below the frontier is re-read beyond the harmless fallback case.
   Confirm in Snowflake that the interleaved real key is present after the restart.
   With the feature off, confirm the connector re-reads from `durableToken + 1` exactly as before, so the default path is unchanged.
