### PR TITLE
CC-41637: Fix ghost lag and restart re-read in Snowpipe Streaming by committing the decided frontier

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/DefaultConnectorConfigValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/DefaultConnectorConfigValidator.java
@@ -139,12 +139,37 @@ public class DefaultConnectorConfigValidator implements ConnectorConfigValidator
                 IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
       }
       if (config.containsKey(
-          SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CHANNEL_NAME_INCLUDE_CONNECTOR_NAME_CONFIG)) {
+          SnowflakeSinkConnectorConfig
+              .SNOWPIPE_STREAMING_CHANNEL_NAME_INCLUDE_CONNECTOR_NAME_CONFIG)) {
         invalidConfigParams.put(
             SnowflakeSinkConnectorConfig
                 .SNOWPIPE_STREAMING_CHANNEL_NAME_INCLUDE_CONNECTOR_NAME_CONFIG,
             Utils.formatString(
                 "Streaming channel name version is only available with {}.",
+                IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
+      }
+      if (config.containsKey(SnowflakeSinkConnectorConfig.ENABLE_NULL_RECORD_OFFSET_ADVANCE)) {
+        invalidConfigParams.put(
+            SnowflakeSinkConnectorConfig.ENABLE_NULL_RECORD_OFFSET_ADVANCE,
+            Utils.formatString(
+                "{} is only available with ingestion type: {}.",
+                SnowflakeSinkConnectorConfig.ENABLE_NULL_RECORD_OFFSET_ADVANCE,
+                IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
+      }
+      if (config.containsKey(SnowflakeSinkConnectorConfig.ENABLE_METADATA_FLOOR_RECOVERY)) {
+        invalidConfigParams.put(
+            SnowflakeSinkConnectorConfig.ENABLE_METADATA_FLOOR_RECOVERY,
+            Utils.formatString(
+                "{} is only available with ingestion type: {}.",
+                SnowflakeSinkConnectorConfig.ENABLE_METADATA_FLOOR_RECOVERY,
+                IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
+      }
+      if (config.containsKey(SnowflakeSinkConnectorConfig.METADATA_FLOOR_GROUP_ID)) {
+        invalidConfigParams.put(
+            SnowflakeSinkConnectorConfig.METADATA_FLOOR_GROUP_ID,
+            Utils.formatString(
+                "{} is only available with ingestion type: {}.",
+                SnowflakeSinkConnectorConfig.METADATA_FLOOR_GROUP_ID,
                 IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
       }
     }

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -260,6 +260,22 @@ public class SnowflakeSinkConnectorConfig {
           + " enabled, disabling this config could have ramifications. Please consult Snowflake"
           + " support before setting this to false.";
 
+  // Streaming only: commit the decided frontier (lowest record received but not yet durable or
+  // decided) from preCommit instead of the durable token, so consumer-group lag reflects only
+  // records genuinely in flight instead of growing across skipped nulls and SMT drops. Default
+  // off.
+  public static final String ENABLE_NULL_RECORD_OFFSET_ADVANCE =
+      "enable.null.record.offset.advance";
+  public static final boolean ENABLE_NULL_RECORD_OFFSET_ADVANCE_DEFAULT = false;
+
+  // Streaming only: carry a recovery floor (frontier - 1) in the consumer-offset commit metadata
+  // and read it back at channel open to re-seek to the frontier, so decided runs are not re-read
+  // after restart. Requires ENABLE_NULL_RECORD_OFFSET_ADVANCE and "metadata.floor.group.id" (the
+  // sink's consumer group). A stale or inconsistent floor falls back to durableToken+1. Default
+  // off.
+  public static final String ENABLE_METADATA_FLOOR_RECOVERY = "enable.metadata.floor.recovery";
+  public static final boolean ENABLE_METADATA_FLOOR_RECOVERY_DEFAULT = false;
+
   // related to ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG /
   // enable.streaming.channel.offset.migration above
   public static final String SNOWPIPE_STREAMING_CHANNEL_NAME_INCLUDE_CONNECTOR_NAME_CONFIG =

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -260,21 +260,41 @@ public class SnowflakeSinkConnectorConfig {
           + " enabled, disabling this config could have ramifications. Please consult Snowflake"
           + " support before setting this to false.";
 
-  // Streaming only: commit the decided frontier (lowest record received but not yet durable or
-  // decided) from preCommit instead of the durable token, so consumer-group lag reflects only
-  // records genuinely in flight instead of growing across skipped nulls and SMT drops. Default
-  // off.
   public static final String ENABLE_NULL_RECORD_OFFSET_ADVANCE =
       "enable.null.record.offset.advance";
+  public static final String ENABLE_NULL_RECORD_OFFSET_ADVANCE_DISPLAY =
+      "Enable committed offset advance over skipped records";
   public static final boolean ENABLE_NULL_RECORD_OFFSET_ADVANCE_DEFAULT = false;
+  public static final String ENABLE_NULL_RECORD_OFFSET_ADVANCE_DOC =
+      "Whether the connector commits the decided frontier instead of the durable offset token. The"
+          + " decided frontier is the lowest record received but not yet durable in Snowflake or"
+          + " otherwise decided (dead-lettered or dropped), so the committed offset advances over"
+          + " skipped null records and records dropped by an SMT, and consumer lag reflects only"
+          + " records genuinely in flight. Can only be set if Streaming Snowpipe is enabled";
 
-  // Streaming only: carry a recovery floor (frontier - 1) in the consumer-offset commit metadata
-  // and read it back at channel open to re-seek to the frontier, so decided runs are not re-read
-  // after restart. Requires ENABLE_NULL_RECORD_OFFSET_ADVANCE and "metadata.floor.group.id" (the
-  // sink's consumer group). A stale or inconsistent floor falls back to durableToken+1. Default
-  // off.
   public static final String ENABLE_METADATA_FLOOR_RECOVERY = "enable.metadata.floor.recovery";
+  public static final String ENABLE_METADATA_FLOOR_RECOVERY_DISPLAY =
+      "Enable recovery floor in commit metadata";
   public static final boolean ENABLE_METADATA_FLOOR_RECOVERY_DEFAULT = false;
+  public static final String ENABLE_METADATA_FLOOR_RECOVERY_DOC =
+      "Whether each offset commit carries a recovery floor (the committed offset minus one) in the"
+          + " consumer-offset metadata, which is read back at channel open so the partition"
+          + " re-seeks to the decided frontier and already-decided runs are not re-read after a"
+          + " restart. Requires "
+          + ENABLE_NULL_RECORD_OFFSET_ADVANCE
+          + " and metadata.floor.group.id. A missing, stale, or inconsistent floor falls back to"
+          + " the durable offset token plus one, which is at worst a harmless re-read. Can only be"
+          + " set if Streaming Snowpipe is enabled";
+
+  public static final String METADATA_FLOOR_GROUP_ID = "metadata.floor.group.id";
+  public static final String METADATA_FLOOR_GROUP_ID_DISPLAY = "Recovery floor consumer group id";
+  public static final String METADATA_FLOOR_GROUP_ID_DOC =
+      "The Connect consumer group id of this sink, typically connect-<connector name>, used to"
+          + " read the recovery floor back from the committed consumer-offset metadata at channel"
+          + " open. Required when "
+          + ENABLE_METADATA_FLOOR_RECOVERY
+          + " is enabled; the connector cannot derive it internally because the connector name is"
+          + " transformed before it reaches the sink";
 
   // related to ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG /
   // enable.streaming.channel.offset.migration above

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -389,11 +389,27 @@ public class SnowflakeSinkTask extends SinkTask {
     try {
       offsets.forEach(
           (topicPartition, offsetAndMetadata) -> {
-            long offset = sink.getOffset(topicPartition);
-            if ((ingestionMethodConfig == IngestionMethodConfig.SNOWPIPE && offset != 0)
-                || (ingestionMethodConfig == IngestionMethodConfig.SNOWPIPE_STREAMING
-                    && offset != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE)) {
-              committedOffsets.put(topicPartition, new OffsetAndMetadata(offset));
+            // Commit the decided frontier instead of the durable token. The consumed position
+            // passed to preCommit includes SMT-filtered offsets, so the frontier clears ghost lag
+            // from skipped nulls and SMT drops without passing a record that still needs writing.
+            long frontier = sink.getDecidedFrontier(topicPartition, offsetAndMetadata.offset());
+            if (frontier != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
+              // Carry the recovery floor (frontier - 1) in the commit metadata so open() can
+              // re-seek to max(durableToken, floor) + 1, which lands on the frontier.
+              long floor = frontier - 1L;
+              committedOffsets.put(
+                  topicPartition,
+                  floor < 0L
+                      ? new OffsetAndMetadata(frontier)
+                      : new OffsetAndMetadata(frontier, "floor=" + floor));
+            } else {
+              // Feature off, or Snowpipe V1, or no channel yet: preserve the original behaviour.
+              long offset = sink.getOffset(topicPartition);
+              if ((ingestionMethodConfig == IngestionMethodConfig.SNOWPIPE && offset != 0)
+                  || (ingestionMethodConfig == IngestionMethodConfig.SNOWPIPE_STREAMING
+                      && offset != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE)) {
+                committedOffsets.put(topicPartition, new OffsetAndMetadata(offset));
+              }
             }
           });
     } catch (Exception e) {

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -678,6 +678,36 @@ public class ConnectorConfigDefinition {
             CONNECTOR_CONFIG_DOC,
             13,
             ConfigDef.Width.NONE,
-            ENABLE_STREAMING_INFINITY_HANDLING_DISPLAY);
+            ENABLE_STREAMING_INFINITY_HANDLING_DISPLAY)
+        .define(
+            ENABLE_NULL_RECORD_OFFSET_ADVANCE,
+            ConfigDef.Type.BOOLEAN,
+            ENABLE_NULL_RECORD_OFFSET_ADVANCE_DEFAULT,
+            ConfigDef.Importance.LOW,
+            ENABLE_NULL_RECORD_OFFSET_ADVANCE_DOC,
+            CONNECTOR_CONFIG_DOC,
+            14,
+            ConfigDef.Width.NONE,
+            ENABLE_NULL_RECORD_OFFSET_ADVANCE_DISPLAY)
+        .define(
+            ENABLE_METADATA_FLOOR_RECOVERY,
+            ConfigDef.Type.BOOLEAN,
+            ENABLE_METADATA_FLOOR_RECOVERY_DEFAULT,
+            ConfigDef.Importance.LOW,
+            ENABLE_METADATA_FLOOR_RECOVERY_DOC,
+            CONNECTOR_CONFIG_DOC,
+            15,
+            ConfigDef.Width.NONE,
+            ENABLE_METADATA_FLOOR_RECOVERY_DISPLAY)
+        .define(
+            METADATA_FLOOR_GROUP_ID,
+            ConfigDef.Type.STRING,
+            "",
+            ConfigDef.Importance.LOW,
+            METADATA_FLOOR_GROUP_ID_DOC,
+            CONNECTOR_CONFIG_DOC,
+            16,
+            ConfigDef.Width.NONE,
+            METADATA_FLOOR_GROUP_ID_DISPLAY);
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -54,6 +54,19 @@ public interface SnowflakeSinkService {
   long getOffset(TopicPartition topicPartition);
 
   /**
+   * Returns the decided frontier for this partition: the lowest record received but not yet durable
+   * or decided, or the given consumed high-water mark when nothing is pending. The caller supplies
+   * the high-water mark because it includes SMT-filtered offsets the sink never sees.
+   *
+   * @param topicPartition topic and partition
+   * @param consumedHwm the framework's consumed position for this partition
+   * @return the decided frontier, or {@code -1} when the feature is off or unsupported
+   */
+  default long getDecidedFrontier(TopicPartition topicPartition, long consumedHwm) {
+    return -1L;
+  }
+
+  /**
    * get the number of partitions assigned to this sink service
    *
    * @return number of partitions

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DefaultStreamingConfigValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DefaultStreamingConfigValidator.java
@@ -126,6 +126,8 @@ public class DefaultStreamingConfigValidator implements StreamingConfigValidator
           invalidParams.putAll(validateSchematizationConfig(inputConfig));
 
           invalidParams.putAll(validateChannelNameV2Usage(inputConfig));
+
+          invalidParams.putAll(validateDecidedFrontierConfig(inputConfig));
         }
       } catch (ConfigException exception) {
         invalidParams.put(
@@ -228,6 +230,50 @@ public class DefaultStreamingConfigValidator implements StreamingConfigValidator
               inputConfig.get(inputConfigConverterField),
               IngestionMethodConfig.SNOWPIPE_STREAMING,
               Iterables.toString(DISALLOWED_CONVERTERS_STREAMING)));
+    }
+
+    return invalidParams;
+  }
+
+  private static Map<String, String> validateDecidedFrontierConfig(Map<String, String> config) {
+    Map<String, String> invalidParams = new HashMap<>();
+
+    if (config.containsKey(ENABLE_NULL_RECORD_OFFSET_ADVANCE)) {
+      BOOLEAN_VALIDATOR.ensureValid(
+          ENABLE_NULL_RECORD_OFFSET_ADVANCE, config.get(ENABLE_NULL_RECORD_OFFSET_ADVANCE));
+    }
+    if (config.containsKey(ENABLE_METADATA_FLOOR_RECOVERY)) {
+      BOOLEAN_VALIDATOR.ensureValid(
+          ENABLE_METADATA_FLOOR_RECOVERY, config.get(ENABLE_METADATA_FLOOR_RECOVERY));
+    }
+
+    boolean frontierEnabled =
+        Boolean.parseBoolean(
+            config.getOrDefault(
+                ENABLE_NULL_RECORD_OFFSET_ADVANCE,
+                Boolean.toString(ENABLE_NULL_RECORD_OFFSET_ADVANCE_DEFAULT)));
+    boolean floorRecoveryEnabled =
+        Boolean.parseBoolean(
+            config.getOrDefault(
+                ENABLE_METADATA_FLOOR_RECOVERY,
+                Boolean.toString(ENABLE_METADATA_FLOOR_RECOVERY_DEFAULT)));
+
+    if (floorRecoveryEnabled && !frontierEnabled) {
+      invalidParams.put(
+          ENABLE_METADATA_FLOOR_RECOVERY,
+          Utils.formatString(
+              "{} requires {} to be enabled.",
+              ENABLE_METADATA_FLOOR_RECOVERY,
+              ENABLE_NULL_RECORD_OFFSET_ADVANCE));
+    }
+    if (floorRecoveryEnabled && Strings.isNullOrEmpty(config.get(METADATA_FLOOR_GROUP_ID))) {
+      invalidParams.put(
+          METADATA_FLOOR_GROUP_ID,
+          Utils.formatString(
+              "{} must be set to the sink's Connect consumer group (connect-<connector name>) when"
+                  + " {} is enabled.",
+              METADATA_FLOOR_GROUP_ID,
+              ENABLE_METADATA_FLOOR_RECOVERY));
     }
 
     return invalidParams;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -2,6 +2,8 @@ package com.snowflake.kafka.connector.internal.streaming;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DEFAULT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_METADATA_FLOOR_RECOVERY;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_METADATA_FLOOR_RECOVERY_DEFAULT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.DURATION_BETWEEN_GET_OFFSET_TOKEN_RETRY;
@@ -44,13 +46,18 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import net.snowflake.ingest.streaming.*;
 import net.snowflake.ingest.utils.SFException;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -84,6 +91,29 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
   // channel versions compatible.
   private final AtomicLong currentConsumerGroupOffset =
       new AtomicLong(NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE);
+
+  // Kafka offsets of records this channel has received and that are not yet durable or decided.
+  // An offset enters on receipt in insertRecord, before any write attempt, so records whose
+  // buffering fails or that are skipped while a reset re-seek is pending stay tracked. It leaves
+  // when the durable token passes it (pruned in getDecidedFrontier) or when the record is
+  // dead-lettered/dropped (removed at the drop site). Deliberately kept across channel resets:
+  // discarded records are still pending. min(set) bounds the offset preCommit may commit.
+  private final java.util.TreeSet<Long> pendingRealOffsets = new java.util.TreeSet<>();
+
+  // Whether preCommit commits the decided frontier instead of the durable token.
+  private final boolean enableNullRecordOffsetAdvance;
+
+  // Whether the recovery floor (frontier - 1) is carried in the consumer-offset commit metadata
+  // and read back at open(). Only effective when enableNullRecordOffsetAdvance is also true.
+  private final boolean enableMetadataFloorRecovery;
+
+  // Prefix for the floor value embedded in OffsetAndMetadata.metadata, e.g. "floor=204".
+  private static final String METADATA_FLOOR_PREFIX = "floor=";
+
+  // Config key carrying the Connect sink consumer group id ("connect-<connector name>"). The
+  // original Connect name is not recoverable inside the connector (Utils.convertAppName munges
+  // it), so the group id must be supplied explicitly for the floor to be read back at open().
+  private static final String METADATA_FLOOR_GROUP_ID_CONFIG = "metadata.floor.group.id";
 
   // Indicates whether we need to skip and discard any leftover rows in the current batch, this
   // could happen when the channel gets invalidated and reset, then anything left in the buffer
@@ -245,6 +275,19 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
     this.enableSchemaEvolution = this.enableSchematization && hasSchemaEvolutionPermission;
     this.schemaEvolutionService = schemaEvolutionService;
 
+    this.enableNullRecordOffsetAdvance =
+        Boolean.parseBoolean(
+            this.sfConnectorConfig.getOrDefault(
+                SnowflakeSinkConnectorConfig.ENABLE_NULL_RECORD_OFFSET_ADVANCE,
+                Boolean.toString(
+                    SnowflakeSinkConnectorConfig.ENABLE_NULL_RECORD_OFFSET_ADVANCE_DEFAULT)));
+
+    this.enableMetadataFloorRecovery =
+        Boolean.parseBoolean(
+            this.sfConnectorConfig.getOrDefault(
+                ENABLE_METADATA_FLOOR_RECOVERY,
+                Boolean.toString(ENABLE_METADATA_FLOOR_RECOVERY_DEFAULT)));
+
     this.channelOffsetTokenMigrator = new ChannelOffsetTokenMigrator(conn, telemetryService);
 
     if (isEnableChannelOffsetMigration(sfConnectorConfig)) {
@@ -261,6 +304,10 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
     final long lastCommittedOffsetToken = fetchOffsetTokenWithRetry();
     this.offsetPersistedInSnowflake.set(lastCommittedOffsetToken);
     this.processedOffset.set(lastCommittedOffsetToken);
+    // Fresh (re)open re-seeks and re-reads, so nothing is pending yet.
+    synchronized (pendingRealOffsets) {
+      pendingRealOffsets.clear();
+    }
 
     // setup telemetry and metrics
     String connectorName =
@@ -284,12 +331,127 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
     this.insertErrorMapper = insertErrorMapper;
 
     if (lastCommittedOffsetToken != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
-      this.sinkTaskContext.offset(this.topicPartition, lastCommittedOffsetToken + 1L);
+      // Re-seek to token+1, or to max(token, floor)+1 when a recovery floor was persisted in the
+      // consumer-offset commit metadata. A stale or unreadable floor falls back to token+1.
+      long seekTarget = lastCommittedOffsetToken + 1L;
+      if (enableMetadataFloorRecovery && enableNullRecordOffsetAdvance) {
+        long floorH = readMetadataFloor(lastCommittedOffsetToken);
+        if (floorH > lastCommittedOffsetToken) {
+          seekTarget = floorH + 1L;
+          LOGGER.info(
+              "TopicPartitionChannel:{}, metadata-floor recovery: token={}, floorH={}, seeking"
+                  + " to {} (skipping re-read of skipped run)",
+              this.getChannelName(),
+              lastCommittedOffsetToken,
+              floorH,
+              seekTarget);
+        }
+      }
+      this.sinkTaskContext.offset(this.topicPartition, seekTarget);
+    } else if (enableMetadataFloorRecovery && enableNullRecordOffsetAdvance) {
+      // No durable token yet: prefer the persisted recovery floor over the raw committed offset.
+      // With no floor, fall through to the committed offset, which preCommit keeps at the decided
+      // frontier, so it is at worst a harmless re-read.
+      long floorH = readMetadataFloor(lastCommittedOffsetToken);
+      if (floorH > NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
+        long seekTarget = floorH + 1L;
+        LOGGER.info(
+            "TopicPartitionChannel:{}, token-null metadata-floor recovery: floorH={}, seeking to {}"
+                + " (skipping re-read of leading skipped run)",
+            this.getChannelName(),
+            floorH,
+            seekTarget);
+        this.sinkTaskContext.offset(this.topicPartition, seekTarget);
+      } else {
+        LOGGER.info(
+            "TopicPartitionChannel:{}, offset token is NULL and no recovery floor, relying on Kafka"
+                + " committed offset (clamped to the decided frontier by the commit fix)",
+            this.getChannelName());
+      }
     } else {
       LOGGER.info(
           "TopicPartitionChannel:{}, offset token is NULL, will rely on Kafka to send us the"
               + " correct offset instead",
           this.getChannelName());
+    }
+  }
+
+  /**
+   * Reads the recovery floor persisted in the committed OffsetAndMetadata.metadata for this
+   * connector's consumer group and topic-partition, via AdminClient.listConsumerGroupOffsets.
+   * Best-effort: returns {@link #NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE} on any error, missing
+   * metadata, or inconsistent value, so recovery falls back to token+1. The AdminClient bootstrap
+   * config is sourced from the connector's {@code admin.override.*} properties.
+   */
+  private long readMetadataFloor(long durableToken) {
+    String groupId = this.sfConnectorConfig.get(METADATA_FLOOR_GROUP_ID_CONFIG);
+    if (Strings.isNullOrEmpty(groupId)) {
+      LOGGER.info(
+          "TopicPartitionChannel:{}, metadata-floor read skipped: no '{}' config",
+          this.getChannelName(),
+          METADATA_FLOOR_GROUP_ID_CONFIG);
+      return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+    }
+
+    Properties adminProps = new Properties();
+    for (Map.Entry<String, String> entry : this.sfConnectorConfig.entrySet()) {
+      String key = entry.getKey();
+      if (key.startsWith("admin.override.")) {
+        adminProps.put(key.substring("admin.override.".length()), entry.getValue());
+      }
+    }
+
+    try (AdminClient adminClient = AdminClient.create(adminProps)) {
+      Map<TopicPartition, OffsetAndMetadata> committed =
+          adminClient
+              .listConsumerGroupOffsets(
+                  groupId,
+                  new ListConsumerGroupOffsetsOptions()
+                      .topicPartitions(Collections.singletonList(this.topicPartition)))
+              .partitionsToOffsetAndMetadata()
+              .get(5, TimeUnit.SECONDS);
+      OffsetAndMetadata oam = committed == null ? null : committed.get(this.topicPartition);
+      if (oam == null
+          || oam.metadata() == null
+          || !oam.metadata().startsWith(METADATA_FLOOR_PREFIX)) {
+        LOGGER.info(
+            "TopicPartitionChannel:{}, metadata-floor read: no floor in committed metadata"
+                + " (group={}, token={}, committedOffset={}, metadata={})",
+            this.getChannelName(),
+            groupId,
+            durableToken,
+            oam == null ? "<none>" : oam.offset(),
+            oam == null ? "<none>" : oam.metadata());
+        return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+      }
+      long parsed = Long.parseLong(oam.metadata().substring(METADATA_FLOOR_PREFIX.length()));
+      // Every commit this connector writes carries floor == committedOffset - 1. A mismatched
+      // floor was written by something else (for example a mis-pointed metadata.floor.group.id),
+      // and honoring a foreign floor could seek past records this connector never wrote.
+      if (parsed != oam.offset() - 1L) {
+        LOGGER.warn(
+            "TopicPartitionChannel:{}, metadata-floor read: floorH={} inconsistent with committed"
+                + " offset {} (expected committedOffset-1); ignoring floor (group={}, token={})",
+            this.getChannelName(),
+            parsed,
+            oam.offset(),
+            groupId,
+            durableToken);
+        return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+      }
+      LOGGER.info(
+          "TopicPartitionChannel:{}, metadata-floor read: floorH={} (group={}, token={})",
+          this.getChannelName(),
+          parsed,
+          groupId,
+          durableToken);
+      return parsed;
+    } catch (Exception e) {
+      LOGGER.info(
+          "TopicPartitionChannel:{}, metadata-floor read failed, falling back to token+1: {}",
+          this.getChannelName(),
+          e.getMessage());
+      return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
     }
   }
 
@@ -336,6 +498,13 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
 
     // Simply skip inserting into the buffer if the row should be ignored after channel reset
     if (needToSkipCurrentBatch) {
+      // Skipped only because a reset re-seeked Kafka; the record is undecided and will be
+      // re-delivered, so track it to keep the frontier from passing it in the meantime.
+      if (enableNullRecordOffsetAdvance) {
+        synchronized (pendingRealOffsets) {
+          pendingRealOffsets.add(kafkaSinkRecord.kafkaOffset());
+        }
+      }
       LOGGER.info(
           "Ignore inserting offset:{} for channel:{} because we recently reset offset in"
               + " Kafka. currentProcessedOffset:{}",
@@ -348,6 +517,14 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
     // incoming record offset is 1 + the processed offset
     if (currentProcessedOffset == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE
         || kafkaSinkRecord.kafkaOffset() >= currentProcessedOffset + 1) {
+      // Track before any write attempt: if the insert fails mid-flight the record is still
+      // undecided and must keep bounding the frontier. The dedup branch below deliberately does
+      // not track; a record at or below processedOffset was already handled.
+      if (enableNullRecordOffsetAdvance) {
+        synchronized (pendingRealOffsets) {
+          pendingRealOffsets.add(kafkaSinkRecord.kafkaOffset());
+        }
+      }
       transformAndSend(kafkaSinkRecord);
     } else {
       LOGGER.warn(
@@ -434,6 +611,12 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
               response.hasErrors());
 
           handleInsertRowFailure(response.getInsertErrors(), kafkaSinkRecord);
+        }
+      } else if (enableNullRecordOffsetAdvance) {
+        // An empty transformed record was dead-lettered or deliberately dropped by
+        // transformDataBeforeSending; it is decided and must stop bounding the frontier.
+        synchronized (pendingRealOffsets) {
+          pendingRealOffsets.remove(kafkaSinkRecord.kafkaOffset());
         }
       }
 
@@ -578,6 +761,13 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
                         new IllegalStateException(
                             "Reported record error, however exception list is empty.")));
       }
+      // Under error tolerance the record is decided (dead-lettered or dropped) and must stop
+      // bounding the frontier. The reporter blocks until the DLQ produce completes.
+      if (enableNullRecordOffsetAdvance) {
+        synchronized (pendingRealOffsets) {
+          pendingRealOffsets.remove(kafkaSinkRecord.kafkaOffset());
+        }
+      }
     } else {
       final String errMsg =
           String.format(
@@ -600,6 +790,38 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
       // Idea of sending + 1 back to Kafka is that it should start sending offsets after task
       // restart from this offset
       return committedOffsetInSnowflake + 1;
+    }
+  }
+
+  /**
+   * Returns the decided frontier: the lowest record received but not yet durable or decided, capped
+   * at the given consumed high-water mark, or the high-water mark itself when nothing is pending.
+   * Everything strictly below the frontier is durably written, a skipped null, a dead-lettered
+   * record, or an SMT/converter drop, so committing the frontier clears ghost lag without ever
+   * stepping over a record that still needs to be written. The caller supplies the high-water mark
+   * because it includes SMT-filtered offsets the connector never sees.
+   *
+   * @param consumedHwm the framework's consumed position for this partition
+   * @return the decided frontier, or {@link #NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE} when the
+   *     feature is off
+   */
+  @Override
+  public long getDecidedFrontier(long consumedHwm) {
+    if (!enableNullRecordOffsetAdvance) {
+      return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+    }
+    final long durableToken = fetchOffsetTokenWithRetry();
+    synchronized (pendingRealOffsets) {
+      // Prune records the durable token has passed.
+      if (durableToken != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
+        pendingRealOffsets.headSet(durableToken + 1L).clear();
+      }
+      if (pendingRealOffsets.isEmpty()) {
+        return consumedHwm;
+      }
+      // Cap at the consumed position: entries retained across a reset can sit above it after the
+      // rewind regresses the consumed position to the seek target.
+      return Math.min(pendingRealOffsets.first(), consumedHwm);
     }
   }
 
@@ -726,6 +948,11 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
     // might get rejected.
     this.offsetPersistedInSnowflake.set(offsetRecoveredFromSnowflake);
     this.processedOffset.set(offsetRecoveredFromSnowflake);
+    // Deliberately do NOT clear pendingRealOffsets: the discarded records are still pending, and
+    // the re-seek above is applied only at the next poll's rewind. A commit can run before that
+    // rewind with the pre-reset consumed position, and the retained entries are what keeps the
+    // frontier at or below the first discarded record in that window. Re-delivery covers every
+    // retained entry, and each is pruned when durable or removed when decided.
 
     // Set the flag so that any leftover rows in the buffer should be skipped, it will be
     // re-ingested since the offset in kafka was reset

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -110,11 +110,6 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
   // Prefix for the floor value embedded in OffsetAndMetadata.metadata, e.g. "floor=204".
   private static final String METADATA_FLOOR_PREFIX = "floor=";
 
-  // Config key carrying the Connect sink consumer group id ("connect-<connector name>"). The
-  // original Connect name is not recoverable inside the connector (Utils.convertAppName munges
-  // it), so the group id must be supplied explicitly for the floor to be read back at open().
-  private static final String METADATA_FLOOR_GROUP_ID_CONFIG = "metadata.floor.group.id";
-
   // Indicates whether we need to skip and discard any leftover rows in the current batch, this
   // could happen when the channel gets invalidated and reset, then anything left in the buffer
   // should be skipped
@@ -384,33 +379,18 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
    * config is sourced from the connector's {@code admin.override.*} properties.
    */
   private long readMetadataFloor(long durableToken) {
-    String groupId = this.sfConnectorConfig.get(METADATA_FLOOR_GROUP_ID_CONFIG);
+    String groupId =
+        this.sfConnectorConfig.get(SnowflakeSinkConnectorConfig.METADATA_FLOOR_GROUP_ID);
     if (Strings.isNullOrEmpty(groupId)) {
       LOGGER.info(
           "TopicPartitionChannel:{}, metadata-floor read skipped: no '{}' config",
           this.getChannelName(),
-          METADATA_FLOOR_GROUP_ID_CONFIG);
+          SnowflakeSinkConnectorConfig.METADATA_FLOOR_GROUP_ID);
       return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
     }
 
-    Properties adminProps = new Properties();
-    for (Map.Entry<String, String> entry : this.sfConnectorConfig.entrySet()) {
-      String key = entry.getKey();
-      if (key.startsWith("admin.override.")) {
-        adminProps.put(key.substring("admin.override.".length()), entry.getValue());
-      }
-    }
-
-    try (AdminClient adminClient = AdminClient.create(adminProps)) {
-      Map<TopicPartition, OffsetAndMetadata> committed =
-          adminClient
-              .listConsumerGroupOffsets(
-                  groupId,
-                  new ListConsumerGroupOffsetsOptions()
-                      .topicPartitions(Collections.singletonList(this.topicPartition)))
-              .partitionsToOffsetAndMetadata()
-              .get(5, TimeUnit.SECONDS);
-      OffsetAndMetadata oam = committed == null ? null : committed.get(this.topicPartition);
+    try {
+      OffsetAndMetadata oam = fetchCommittedOffsetAndMetadata(groupId);
       if (oam == null
           || oam.metadata() == null
           || !oam.metadata().startsWith(METADATA_FLOOR_PREFIX)) {
@@ -452,6 +432,35 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
           this.getChannelName(),
           e.getMessage());
       return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+    }
+  }
+
+  /**
+   * Fetches the committed OffsetAndMetadata for this topic-partition from the given consumer group,
+   * via AdminClient.listConsumerGroupOffsets. The AdminClient bootstrap config is sourced from the
+   * connector's {@code admin.override.*} properties. Package-private so tests can stub the broker
+   * interaction.
+   */
+  @VisibleForTesting
+  OffsetAndMetadata fetchCommittedOffsetAndMetadata(String groupId) throws Exception {
+    Properties adminProps = new Properties();
+    for (Map.Entry<String, String> entry : this.sfConnectorConfig.entrySet()) {
+      String key = entry.getKey();
+      if (key.startsWith("admin.override.")) {
+        adminProps.put(key.substring("admin.override.".length()), entry.getValue());
+      }
+    }
+
+    try (AdminClient adminClient = AdminClient.create(adminProps)) {
+      Map<TopicPartition, OffsetAndMetadata> committed =
+          adminClient
+              .listConsumerGroupOffsets(
+                  groupId,
+                  new ListConsumerGroupOffsetsOptions()
+                      .topicPartitions(Collections.singletonList(this.topicPartition)))
+              .partitionsToOffsetAndMetadata()
+              .get(5, TimeUnit.SECONDS);
+      return committed == null ? null : committed.get(this.topicPartition);
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -144,7 +144,9 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     boolean infinityHandlingEnabled = Utils.isStreamingInfinityHandlingEnabled(connectorConfig);
     this.recordService =
         RecordServiceFactory.createRecordService(
-            Utils.isIcebergEnabled(connectorConfig), schematizationEnabled, infinityHandlingEnabled);
+            Utils.isIcebergEnabled(connectorConfig),
+            schematizationEnabled,
+            infinityHandlingEnabled);
     this.icebergTableSchemaValidator = new IcebergTableSchemaValidator(conn);
     this.icebergInitService = new IcebergInitService(conn);
     this.schemaEvolutionService =
@@ -310,6 +312,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     for (SinkRecord record : records) {
       // check if it needs to handle null value records
       if (recordService.shouldSkipNullValue(record, behaviorOnNullValues)) {
+        // A skipped null is decided by definition; the frontier steps over untracked offsets.
         continue;
       }
 
@@ -361,6 +364,14 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
           topicPartition.partition());
       return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
     }
+  }
+
+  @Override
+  public long getDecidedFrontier(TopicPartition topicPartition, long consumedHwm) {
+    String partitionChannelKey =
+        partitionChannelKey(topicPartition.topic(), topicPartition.partition());
+    TopicPartitionChannel channel = partitionsToChannel.get(partitionChannelKey);
+    return channel == null ? -1L : channel.getDecidedFrontier(consumedHwm);
   }
 
   @Override

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/TopicPartitionChannel.java
@@ -81,4 +81,17 @@ public interface TopicPartitionChannel extends ExposingInternalsTopicPartitionCh
   String getChannelName();
 
   void setLatestConsumerGroupOffset(long consumerOffset);
+
+  /**
+   * Returns the decided frontier: the lowest record received but not yet durable or decided, or the
+   * given consumed high-water mark when nothing is pending. Both the committed offset and the
+   * recovery floor carried in the commit metadata derive from this number.
+   *
+   * @param consumedHwm the framework's consumed position for this partition
+   * @return the decided frontier, or {@code NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE} when the
+   *     feature is off
+   */
+  default long getDecidedFrontier(long consumedHwm) {
+    return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+  }
 }

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
@@ -1055,6 +1055,45 @@ public class ConnectorConfigValidatorTest {
         .hasMessageContaining(SnowflakeSinkConnectorConfig.OAUTH_REFRESH_TOKEN);
   }
 
+  // ---------- Decided frontier / metadata floor recovery tests ---------- //
+  @Test
+  public void testDecidedFrontierConfig_validStreamingConfig() {
+    Map<String, String> config = SnowflakeSinkConnectorConfigBuilder.streamingConfig().build();
+    config.put(ENABLE_NULL_RECORD_OFFSET_ADVANCE, "true");
+    config.put(ENABLE_METADATA_FLOOR_RECOVERY, "true");
+    config.put(METADATA_FLOOR_GROUP_ID, "connect-test-connector");
+    connectorConfigValidator.validateConfig(config);
+  }
+
+  @Test
+  public void testDecidedFrontierConfig_notAllowedWithSnowpipe() {
+    Map<String, String> config = SnowflakeSinkConnectorConfigBuilder.snowpipeConfig().build();
+    config.put(ENABLE_NULL_RECORD_OFFSET_ADVANCE, "true");
+    assertThatThrownBy(() -> connectorConfigValidator.validateConfig(config))
+        .isInstanceOf(SnowflakeKafkaConnectorException.class)
+        .hasMessageContaining(ENABLE_NULL_RECORD_OFFSET_ADVANCE);
+  }
+
+  @Test
+  public void testMetadataFloorRecovery_requiresNullRecordOffsetAdvance() {
+    Map<String, String> config = SnowflakeSinkConnectorConfigBuilder.streamingConfig().build();
+    config.put(ENABLE_METADATA_FLOOR_RECOVERY, "true");
+    config.put(METADATA_FLOOR_GROUP_ID, "connect-test-connector");
+    assertThatThrownBy(() -> connectorConfigValidator.validateConfig(config))
+        .isInstanceOf(SnowflakeKafkaConnectorException.class)
+        .hasMessageContaining(ENABLE_METADATA_FLOOR_RECOVERY);
+  }
+
+  @Test
+  public void testMetadataFloorRecovery_requiresGroupId() {
+    Map<String, String> config = SnowflakeSinkConnectorConfigBuilder.streamingConfig().build();
+    config.put(ENABLE_NULL_RECORD_OFFSET_ADVANCE, "true");
+    config.put(ENABLE_METADATA_FLOOR_RECOVERY, "true");
+    assertThatThrownBy(() -> connectorConfigValidator.validateConfig(config))
+        .isInstanceOf(SnowflakeKafkaConnectorException.class)
+        .hasMessageContaining(METADATA_FLOOR_GROUP_ID);
+  }
+
   private void invalidConfigRunner(List<String> paramsToRemove) {
     Map<String, String> config = getConfig();
     for (String configParam : paramsToRemove) {

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannelFrontierTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannelFrontierTest.java
@@ -1,0 +1,369 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_METADATA_FLOOR_RECOVERY;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_NULL_RECORD_OFFSET_ADVANCE;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.METADATA_FLOOR_GROUP_ID;
+import static com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
+import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
+import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.TestUtils;
+import com.snowflake.kafka.connector.internal.streaming.schemaevolution.InsertErrorMapper;
+import com.snowflake.kafka.connector.internal.streaming.schemaevolution.SchemaEvolutionService;
+import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
+import net.snowflake.ingest.streaming.InsertValidationResponse;
+import net.snowflake.ingest.streaming.OpenChannelRequest;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
+import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.SFException;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for the decided-frontier pending-set lifecycle (entry at receipt, prune at durable
+ * token, removal on decided drop, retention across channel reset, cap at the consumed position) and
+ * for the metadata-floor recovery seek in the constructor.
+ */
+public class DirectTopicPartitionChannelFrontierTest {
+
+  private static final String TOPIC = "TEST";
+  private static final int PARTITION = 0;
+  private static final String TEST_TABLE_NAME = "TEST_TABLE";
+
+  private SnowflakeStreamingIngestClient mockStreamingClient;
+  private SnowflakeStreamingIngestChannel mockStreamingChannel;
+  private KafkaRecordErrorReporter mockKafkaRecordErrorReporter;
+  private SinkTaskContext mockSinkTaskContext;
+  private SnowflakeConnectionService mockSnowflakeConnectionService;
+  private SnowflakeTelemetryService mockTelemetryService;
+  private SchemaEvolutionService mockSchemaEvolutionService;
+
+  private TopicPartition topicPartition;
+  private String testChannelName;
+  private Map<String, String> sfConnectorConfig;
+
+  // Durable-token holder so tests can move the token between calls without re-stubbing.
+  private final AtomicReference<String> durableToken = new AtomicReference<>(null);
+
+  private static final SFException SF_EXCEPTION =
+      new SFException(ErrorCode.INVALID_CHANNEL, "INVALID_CHANNEL");
+
+  @Before
+  public void setup() {
+    mockStreamingClient = Mockito.mock(SnowflakeStreamingIngestClient.class);
+    mockStreamingChannel = Mockito.mock(SnowflakeStreamingIngestChannel.class);
+    mockKafkaRecordErrorReporter = Mockito.mock(KafkaRecordErrorReporter.class);
+    mockSinkTaskContext = Mockito.mock(SinkTaskContext.class);
+    mockSnowflakeConnectionService = Mockito.mock(SnowflakeConnectionService.class);
+    mockTelemetryService = Mockito.mock(SnowflakeTelemetryService.class);
+    mockSchemaEvolutionService = Mockito.mock(SchemaEvolutionService.class);
+
+    Mockito.when(mockStreamingClient.isClosed()).thenReturn(false);
+    Mockito.when(mockStreamingClient.openChannel(ArgumentMatchers.any(OpenChannelRequest.class)))
+        .thenReturn(mockStreamingChannel);
+    durableToken.set(null);
+    Mockito.when(mockStreamingChannel.getLatestCommittedOffsetToken())
+        .thenAnswer(invocation -> durableToken.get());
+
+    topicPartition = new TopicPartition(TOPIC, PARTITION);
+    testChannelName = SnowflakeSinkServiceV2.partitionChannelKey(null, TOPIC, PARTITION);
+    Mockito.when(mockStreamingChannel.getFullyQualifiedName()).thenReturn(testChannelName);
+
+    sfConnectorConfig = TestUtils.getConfig();
+    sfConnectorConfig.put(ENABLE_NULL_RECORD_OFFSET_ADVANCE, "true");
+  }
+
+  private DirectTopicPartitionChannel createChannel() {
+    return createChannel(mockKafkaRecordErrorReporter);
+  }
+
+  private DirectTopicPartitionChannel createChannel(KafkaRecordErrorReporter errorReporter) {
+    return new DirectTopicPartitionChannel(
+        mockStreamingClient,
+        topicPartition,
+        testChannelName,
+        TEST_TABLE_NAME,
+        sfConnectorConfig,
+        errorReporter,
+        mockSinkTaskContext,
+        mockSnowflakeConnectionService,
+        mockTelemetryService,
+        mockSchemaEvolutionService,
+        new InsertErrorMapper());
+  }
+
+  private void stubCleanInserts() {
+    Mockito.when(mockStreamingChannel.insertRow(anyMap(), anyString()))
+        .thenReturn(new InsertValidationResponse());
+  }
+
+  private List<SinkRecord> records(int startOffset, int count) throws Exception {
+    return TestUtils.createJsonStringSinkRecords(startOffset, count, TOPIC, PARTITION);
+  }
+
+  @Test
+  public void testGetDecidedFrontier_featureOff_returnsSentinel() throws Exception {
+    sfConnectorConfig.remove(ENABLE_NULL_RECORD_OFFSET_ADVANCE);
+    stubCleanInserts();
+    DirectTopicPartitionChannel channel = createChannel();
+
+    List<SinkRecord> batch = records(0, 3);
+    for (int idx = 0; idx < batch.size(); idx++) {
+      channel.insertRecord(batch.get(idx), idx == 0);
+    }
+
+    Assert.assertEquals(NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE, channel.getDecidedFrontier(42L));
+  }
+
+  @Test
+  public void testGetDecidedFrontier_nothingPending_returnsConsumedHwm() {
+    DirectTopicPartitionChannel channel = createChannel();
+
+    Assert.assertEquals(42L, channel.getDecidedFrontier(42L));
+  }
+
+  @Test
+  public void testPendingSet_entryAtReceipt_boundsFrontier() throws Exception {
+    stubCleanInserts();
+    DirectTopicPartitionChannel channel = createChannel();
+
+    List<SinkRecord> batch = records(0, 5);
+    for (int idx = 0; idx < batch.size(); idx++) {
+      channel.insertRecord(batch.get(idx), idx == 0);
+    }
+
+    // Nothing durable yet, so the lowest received record bounds the frontier.
+    Assert.assertEquals(0L, channel.getDecidedFrontier(10L));
+  }
+
+  @Test
+  public void testPendingSet_prunedByDurableToken() throws Exception {
+    stubCleanInserts();
+    DirectTopicPartitionChannel channel = createChannel();
+
+    List<SinkRecord> batch = records(0, 5);
+    for (int idx = 0; idx < batch.size(); idx++) {
+      channel.insertRecord(batch.get(idx), idx == 0);
+    }
+
+    durableToken.set("2");
+    Assert.assertEquals(3L, channel.getDecidedFrontier(10L));
+
+    durableToken.set("4");
+    Assert.assertEquals(10L, channel.getDecidedFrontier(10L));
+  }
+
+  @Test
+  public void testGetDecidedFrontier_cappedAtConsumedHwm() throws Exception {
+    stubCleanInserts();
+    DirectTopicPartitionChannel channel = createChannel();
+
+    List<SinkRecord> batch = records(3, 2);
+    for (int idx = 0; idx < batch.size(); idx++) {
+      channel.insertRecord(batch.get(idx), idx == 0);
+    }
+
+    // Pending is {3, 4} but the consumed position sits below it, e.g. after a rewind.
+    Assert.assertEquals(1L, channel.getDecidedFrontier(1L));
+  }
+
+  @Test
+  public void testPendingSet_decidedDropRemoval_deadLetteredRecord() throws Exception {
+    InsertValidationResponse errorResponse = new InsertValidationResponse();
+    InsertValidationResponse.InsertError insertError =
+        new InsertValidationResponse.InsertError("CONTENT", 0);
+    insertError.setException(SF_EXCEPTION);
+    errorResponse.addError(insertError);
+    Mockito.when(mockStreamingChannel.insertRow(anyMap(), anyString())).thenReturn(errorResponse);
+
+    sfConnectorConfig.put(
+        ERRORS_TOLERANCE_CONFIG, SnowflakeSinkConnectorConfig.ErrorTolerance.ALL.toString());
+    sfConnectorConfig.put(ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG, "dlq_topic");
+
+    InMemoryKafkaRecordErrorReporter errorReporter = new InMemoryKafkaRecordErrorReporter();
+    DirectTopicPartitionChannel channel = createChannel(errorReporter);
+
+    channel.insertRecord(records(0, 1).get(0), true);
+
+    // The record was dead-lettered, so it is decided and no longer bounds the frontier.
+    Assert.assertEquals(1, errorReporter.getReportedRecords().size());
+    Assert.assertEquals(5L, channel.getDecidedFrontier(5L));
+  }
+
+  @Test
+  public void testPendingSet_retainedAcrossChannelReset() throws Exception {
+    Mockito.when(mockStreamingChannel.insertRow(anyMap(), eq("0")))
+        .thenReturn(new InsertValidationResponse());
+    Mockito.when(mockStreamingChannel.insertRow(anyMap(), eq("1"))).thenThrow(SF_EXCEPTION);
+
+    DirectTopicPartitionChannel channel = createChannel();
+
+    List<SinkRecord> batch = records(0, 3);
+    channel.insertRecord(batch.get(0), true);
+
+    // Record 0 becomes durable; record 1 fails the insert, which resets the channel and requests
+    // a re-seek to 1.
+    durableToken.set("0");
+    channel.insertRecord(batch.get(1), false);
+    Mockito.verify(mockSinkTaskContext).offset(topicPartition, 1L);
+
+    // Record 1 is discarded but still undecided, so it must keep bounding the frontier inside the
+    // window between the reset and the rewind.
+    Assert.assertEquals(1L, channel.getDecidedFrontier(2L));
+
+    // Leftover batch records are skipped while the re-seek is pending, but stay tracked.
+    channel.insertRecord(batch.get(2), false);
+    Assert.assertEquals(1L, channel.getDecidedFrontier(3L));
+  }
+
+  /**
+   * Overrides the broker read so floor-recovery tests can run without an AdminClient. A static
+   * holder is used because the base constructor invokes the override before instance fields of this
+   * subclass are initialized.
+   */
+  private static class FloorStubbedChannel extends DirectTopicPartitionChannel {
+    private static Callable<OffsetAndMetadata> committedStub;
+
+    FloorStubbedChannel(
+        SnowflakeStreamingIngestClient streamingIngestClient,
+        TopicPartition topicPartition,
+        String channelName,
+        String tableName,
+        Map<String, String> sfConnectorConfig,
+        KafkaRecordErrorReporter kafkaRecordErrorReporter,
+        SinkTaskContext sinkTaskContext,
+        SnowflakeConnectionService conn,
+        SnowflakeTelemetryService telemetryService,
+        SchemaEvolutionService schemaEvolutionService) {
+      super(
+          streamingIngestClient,
+          topicPartition,
+          channelName,
+          tableName,
+          sfConnectorConfig,
+          kafkaRecordErrorReporter,
+          sinkTaskContext,
+          conn,
+          telemetryService,
+          schemaEvolutionService,
+          new InsertErrorMapper());
+    }
+
+    @Override
+    OffsetAndMetadata fetchCommittedOffsetAndMetadata(String groupId) throws Exception {
+      return committedStub.call();
+    }
+  }
+
+  private FloorStubbedChannel createFloorChannel(Callable<OffsetAndMetadata> committedStub) {
+    FloorStubbedChannel.committedStub = committedStub;
+    return new FloorStubbedChannel(
+        mockStreamingClient,
+        topicPartition,
+        testChannelName,
+        TEST_TABLE_NAME,
+        sfConnectorConfig,
+        mockKafkaRecordErrorReporter,
+        mockSinkTaskContext,
+        mockSnowflakeConnectionService,
+        mockTelemetryService,
+        mockSchemaEvolutionService);
+  }
+
+  private void enableFloorRecovery() {
+    sfConnectorConfig.put(ENABLE_METADATA_FLOOR_RECOVERY, "true");
+    sfConnectorConfig.put(METADATA_FLOOR_GROUP_ID, "connect-test-connector");
+  }
+
+  @Test
+  public void testFloorRecovery_consistentFloorAboveToken_seeksToFloorPlusOne() {
+    enableFloorRecovery();
+    durableToken.set("4");
+    createFloorChannel(() -> new OffsetAndMetadata(10L, "floor=9"));
+
+    Mockito.verify(mockSinkTaskContext).offset(topicPartition, 10L);
+  }
+
+  @Test
+  public void testFloorRecovery_tokenNull_seeksToFloorPlusOne() {
+    enableFloorRecovery();
+    durableToken.set(null);
+    createFloorChannel(() -> new OffsetAndMetadata(10L, "floor=9"));
+
+    Mockito.verify(mockSinkTaskContext).offset(topicPartition, 10L);
+  }
+
+  @Test
+  public void testFloorRecovery_floorBelowToken_seeksToTokenPlusOne() {
+    enableFloorRecovery();
+    durableToken.set("9");
+    createFloorChannel(() -> new OffsetAndMetadata(5L, "floor=4"));
+
+    Mockito.verify(mockSinkTaskContext).offset(topicPartition, 10L);
+  }
+
+  @Test
+  public void testFloorRecovery_inconsistentFloor_ignored() {
+    enableFloorRecovery();
+    durableToken.set("4");
+    // Every commit this connector writes satisfies floor == committedOffset - 1, so this floor was
+    // written by something else and must not be honored.
+    createFloorChannel(() -> new OffsetAndMetadata(10L, "floor=5"));
+
+    Mockito.verify(mockSinkTaskContext).offset(topicPartition, 5L);
+  }
+
+  @Test
+  public void testFloorRecovery_noFloorInMetadata_seeksToTokenPlusOne() {
+    enableFloorRecovery();
+    durableToken.set("4");
+    createFloorChannel(() -> new OffsetAndMetadata(10L, ""));
+
+    Mockito.verify(mockSinkTaskContext).offset(topicPartition, 5L);
+  }
+
+  @Test
+  public void testFloorRecovery_readFailure_seeksToTokenPlusOne() {
+    enableFloorRecovery();
+    durableToken.set("4");
+    createFloorChannel(
+        () -> {
+          throw new RuntimeException("broker unavailable");
+        });
+
+    Mockito.verify(mockSinkTaskContext).offset(topicPartition, 5L);
+  }
+
+  @Test
+  public void testFloorRecovery_missingGroupId_skipsReadAndSeeksToTokenPlusOne() {
+    sfConnectorConfig.put(ENABLE_METADATA_FLOOR_RECOVERY, "true");
+    durableToken.set("4");
+    // AssertionError is not caught by the floor read's exception handling, so a read attempt
+    // would fail the test.
+    createFloorChannel(
+        () -> {
+          throw new AssertionError("floor read should be skipped without a group id");
+        });
+
+    Mockito.verify(mockSinkTaskContext).offset(topicPartition, 5L);
+  }
+}


### PR DESCRIPTION
Jira: CC-41637

## Problem

When a Snowflake sink running Snowpipe Streaming is configured with `behavior.on.null.values=IGNORE` and consumes a long run of tombstones, or when a Filter SMT drops records upstream of the connector, the connector correctly writes nothing, but `preCommit` keeps returning the durable offset token, which only advances when a real row is persisted. Two symptoms follow:

1. Ghost lag: the committed Kafka offset freezes while the log-end offset climbs, so every monitoring surface reports unbounded, permanent lag on a healthy connector.
2. Restart re-read: on restart the connector re-seeks to `durableToken + 1` and re-reads, then re-drops, the entire run above the frozen token.

## The fix

`preCommit` now returns the decided frontier for streaming channels instead of the raw durable token. The frontier is the lowest record the channel has received that is not yet durable or decided (dead-lettered or deliberately dropped), capped at the consumed position the framework hands `preCommit`; when nothing is pending it is the consumed position itself. Everything strictly below the frontier is durably written, a skipped null, a dead-lettered record, or an SMT/converter drop the framework itself has settled, so committing it clears the lag for both null records and SMT drops without ever committing past a record that still needs to be written.

Each commit also carries a recovery floor, `frontier - 1`, in the `OffsetAndMetadata` metadata string of the consumer-offset commit the connector already makes. On channel open the floor is read back through `AdminClient.listConsumerGroupOffsets` and the partition re-seeks to `max(durableToken, floor) + 1`, which lands exactly on the frontier, so decided runs are not re-read after a restart either.

## Why this is safe

The safety argument rests on one invariant: every record the framework has consumed is, at every commit, either durable in Snowflake or present in the channel's pending set. The set is maintained to make that invariant hold unconditionally:

- A record enters the set at receipt in `insertRecord`, before any write attempt. This deliberately covers the two records a buffer-time set would miss: a record whose insert fails (the SFException fallback resets the channel and the exception is swallowed, yet the consumed position still covers the record once `put()` returns) and the remainder of a batch skipped through `needToSkipCurrentBatch` after a reset.
- A record leaves the set for exactly two reasons: the durable token passed it (pruned during the frontier computation), or it was decided, meaning dead-lettered (the reporter blocks until the DLQ produce completes) or deliberately dropped. Nothing else removes entries.
- The set is intentionally kept across mid-flight channel resets. The runtime applies a requested re-seek only at the top of its next poll, while the commit path can run before that, so a commit can observe the pre-reset consumed position; the retained entries are what keeps the frontier at or below the first discarded record inside that window. Every retained entry sits at or above the re-seek target, so re-delivery covers all of them.
- The frontier is additionally capped at the consumed position, which matters after the rewind regresses the consumed position below entries retained across a reset.

Recovery is defensive on top of that. A missing floor, an unreadable floor, or a floor inconsistent with the committed offset it rides on (every commit this change writes satisfies `floor == committedOffset - 1`, so a mismatch means it was written by something else, for example a mis-pointed `metadata.floor.group.id`) is discarded and recovery falls back to `durableToken + 1`, which is the pre-existing behaviour and at worst a harmless re-read. Rolling back to a build without this change is also safe: the old code ignores the commit metadata entirely and re-seeks to the token.

Both behaviours are off by default and the change is inert unless enabled: with the flags off, `preCommit` takes the original token-based path and no metadata is attached. The change applies to Snowpipe Streaming only; the Snowpipe (V1) path is untouched, and the frontier accessor defaults keep every other `SnowflakeSinkService` implementation unchanged. The change adds no new write path to Snowflake, so exactly-once semantics of the channel offset token protocol are untouched; only the advisory committed offset and the recovery seek target move.

## Configuration

- `enable.null.record.offset.advance` (default `false`): commit the decided frontier from `preCommit`.
- `enable.metadata.floor.recovery` (default `false`): carry and honour the recovery floor; requires the flag above and `metadata.floor.group.id`, the sink's Connect consumer group (`connect-<connector name>`), which cannot be derived inside the connector because the name config is munged.

## Testing

Verified on an internal end-to-end harness in two tiers, with the feature exercised on a stock Connect runtime:

- Embedded Connect cluster (real broker, real consumer-group offsets) with an async-durability fake ingest: all-tombstone lag drains to zero; Filter-SMT interleaved lag drains to zero; restart with floor recovery resumes at the frontier with zero re-read and zero loss; token-null interleaved restart loses nothing; two reset-window scenarios (mid-flight channel reset followed by a stop inside the commit window, with and without a durable token) land every record. The unpatched frontier-without-receipt-tracking variant loses records in exactly those reset-window scenarios, which validates that the tests reach the window.
- Docker with real Snowflake ingest: lag drain and floor-recovery restart confirmed against a real account, no re-read, no loss, no duplicates.
- Real Snowflake ingest with fault injection: both reset-window scenarios were additionally run against a real account by wrapping the real ingest SDK in a delegating test proxy that forces the in-commit channel reset; the fix lands every record with exact key-set verification, and the unhardened baseline loses exactly the records the safety analysis predicts, confirming the window is genuinely exercised.

## Before undrafting

- [x] Register the three new config keys in `ConnectorConfigDefinition` and document them. Done, including cross-field validation: all three keys are rejected under Snowpipe (V1) ingestion, and `enable.metadata.floor.recovery` requires `enable.null.record.offset.advance` plus a non-empty `metadata.floor.group.id`.
- [x] Add unit tests for the pending-set lifecycle (receipt entry, decided-drop removal, retention across reset) and the floor read-back. Done: `DirectTopicPartitionChannelFrontierTest` covers the lifecycle and every floor-recovery branch, and `ConnectorConfigValidatorTest` covers the new validation rules.
- [x] A real-Snowflake reset-window run with fault injection in the ingest path. Done on an internal harness: a delegating test wrapper around the real ingest SDK injects a transient token-read failure inside the commit path, forcing the in-commit channel reset against a real account while durability, token recovery, and re-delivery all run against the real service. Both reset-window scenarios (durable token with floor recovery on, token-null bootstrap with floor recovery off) land every record, verified by exact key-set queries on the destination table, and the unhardened baseline loses exactly the predicted records under the same gate, which proves the gate reaches the poison window.


