### PR TITLE
CC-42523 Set enable.streaming.channel.offset.migration default to false

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -252,7 +252,7 @@ public class SnowflakeSinkConnectorConfig {
       "enable.streaming.channel.offset.migration";
   public static final String ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DISPLAY =
       "Enable Streaming Channel Offset Migration";
-  public static final boolean ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DEFAULT = true;
+  public static final boolean ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DEFAULT = false;
   public static final String ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DOC =
       "This config is used to enable/disable streaming channel offset migration logic. If true, we"
           + " will migrate offset token from channel name format V2 to name format v1. V2 channel"

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -549,6 +549,8 @@ public class TopicPartitionChannelIT {
   public void testChannelMigrateOffsetTokenSystemFunction_NonNullOffsetTokenForSourceChannel()
       throws Exception {
     Map<String, String> config = getConfForStreaming();
+    // Enable offset migration for this test
+    config.put(SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG, "true");
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
@@ -632,6 +634,8 @@ public class TopicPartitionChannelIT {
   public void testChannelMigrateOffsetTokenSystemFunction_NullOffsetTokenInFormatV2()
       throws Exception {
     Map<String, String> config = getConfForStreaming();
+    // Enable offset migration for this test
+    config.put(SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG, "true");
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
 
     InMemorySinkTaskContext inMemorySinkTaskContext =


### PR DESCRIPTION
Currently we have set enable.streaming.channel.offset.migration default to true, but we want it to false as this setting is causing some connectors to fail with error `Streaming Channel Offset Migration from Source to Destination Channel has no/invalid response`.

This `SYSTEM$SNOWPIPE_STREAMING_MIGRATE_CHANNEL_OFFSET_TOKEN` function is only needed as a one-time execution IF we have used the "bad" version 2.1.0 which had a different channel name format but confluent cloud is currently using 3.1.0 in the fully managed connector, so we should be good setting this default to false.

IT's are passing here -> https://github.com/confluentinc/snowflake-kafka-connector-private/pull/382