### PR TITLE
Add INFO log for skipped null-valued records in V1 and V2 sink services

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -221,6 +221,11 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
     for (SinkRecord record : records) {
       // check if it needs to handle null value records
       if (recordService.shouldSkipNullValue(record, behaviorOnNullValues)) {
+        LOGGER.info(
+            "Skipping record with null value. Topic: {}, Partition: {}, Offset: {}",
+            record.topic(),
+            record.kafkaPartition(),
+            record.kafkaOffset());
         continue;
       }
       // Might happen a count of record based flushing

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -310,6 +310,11 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     for (SinkRecord record : records) {
       // check if it needs to handle null value records
       if (recordService.shouldSkipNullValue(record, behaviorOnNullValues)) {
+        LOGGER.info(
+            "Skipping record with null value. Topic: {}, Partition: {}, Offset: {}",
+            record.topic(),
+            record.kafkaPartition(),
+            record.kafkaOffset());
         continue;
       }
 


### PR DESCRIPTION
### Why this change is the right one
Currently, when a record has a null value, the Snowflake Kafka Connector skips processing it if configured to do so. The decision to skip is made inside the record service's shouldSkipNullValue method, which logs the skip decision at a debug log level. Since debug logging is typically disabled by default in production and testing environments, these skipped records are ignored silently without any visible trace in the default configuration.

By adding an INFO level log in the V1 and V2 sink services immediately before the execution continues to the next record, we ensure that operators have immediate and clear visibility into which records are being skipped due to null values, including their topic name, partition number, and offset.

### Why this change is safe
This change only introduces a standard logger output at the INFO log level and has no impact on the operational logic of the connector. The execution flow is identical to the previous implementation, as the loop still proceeds directly to the next iteration using the continue statement. Therefore, this change is highly safe and has been verified to compile and pass the SnowflakeSinkServiceV1Test suite.